### PR TITLE
ovl/usrsctp: Experiments with userspace SCTP stack

### DIFF
--- a/ovl-index.md
+++ b/ovl-index.md
@@ -46,6 +46,7 @@
  * [test-template](./ovl/test-template/README.md) 
  * [timezone](./ovl/timezone/README.md) 
  * [udp-test](./ovl/udp-test/README.md) 
+ * [usrsctp](./ovl/usrsctp/README.md) 
  * [virtualbox](./ovl/virtualbox/README.md) 
  * [wireguard](./ovl/wireguard/README.md) 
  * [xdp](./ovl/xdp/README.md) 

--- a/ovl/usrsctp/.gitignore
+++ b/ovl/usrsctp/.gitignore
@@ -1,0 +1,2 @@
+image/default/bin/usrsctpt
+captures

--- a/ovl/usrsctp/README.md
+++ b/ovl/usrsctp/README.md
@@ -1,0 +1,4 @@
+# Xcluster/ovl - usrsctp
+
+Test and experiments with 
+https://datatracker.ietf.org/doc/draft-porfiri-tsvwg-sctp-natsupp/

--- a/ovl/usrsctp/default/bin/usrsctp_test
+++ b/ovl/usrsctp/default/bin/usrsctp_test
@@ -1,0 +1,135 @@
+#! /bin/sh
+##
+## sctp_test --
+##
+##   Test script for sctp executed in xcluster.
+##
+## Commands;
+##
+
+prg=$(basename $0)
+dir=$(dirname $0); dir=$(readlink -f $dir)
+me=$dir/$prg
+tmp=/tmp/${prg}_$$
+test -n "$DOMAIN" || DOMAIN=xcluster
+test -n "$PREFIX" || PREFIX=1000::1
+test -n "$FIRST_WORKER" || FIRST_WORKER=1
+yamld=/etc/kubernetes/usrsctp
+
+die() {
+	echo "ERROR: $*" >&2
+	rm -rf $tmp
+	exit 1
+}
+help() {
+	grep '^##' $0 | cut -c3-
+	rm -rf $tmp
+	exit 0
+}
+test -n "$1" || help
+echo "$1" | grep -qi "^help\|-h" && help
+
+log() {
+	echo "$prg: $*" >&2
+}
+dbg() {
+	test -n "$__verbose" && echo "$prg: $*" >&2
+}
+
+cmd_tcase_check_namespaces() {
+    test_namespaces $1
+}
+cmd_tcase_check_nodes() {
+    test_nodes
+}
+
+cmd_tcase_deploy_test_pods() {
+	tcase "Deploy test pods"
+	apply_k8s $yamld
+	test_deployment usrsctp-test 180
+	assign-lb-ip -svc usrsctp -ip 10.0.0.72,1000::72
+}
+
+cmd_tcase_start_server() {
+	tcase "Start server"
+	local cmd="usrsctpt server --log=7 --addr=192.168.3.221,192.168.4.221 --port=7003"
+	local log=/var/log/usrsctp.log
+	tlog $cmd
+	nohup $cmd > $log 2>&1 &
+	tlog "Check usrsctpt has started"
+	tex "pgrep usrsctpt" || tdie
+}
+
+cmd_tcase_start_client_interactive() {
+	tcase "Start client"
+	#local cmd="usrsctpt client --log=7 --addr=192.168.3.221,192.168.4.221 --port=7003 --laddr=11.0.2.2"
+	local app="app=usrsctp-test"
+	#kubectl_exec $app -- $cmd
+	kubectl_exec $app --stdin -i -- bash
+}
+
+cmd_tcase_vip_ecmp_route() {
+	local net=1
+	test -n "$1" && net=$1
+	tcase "Setup VIP ECMP routes. net=$net"
+	vip_route $net
+}
+cmd_tcase_vip_route() {
+	tcase "Setup VIP route to [$1]"
+	ip ro replace 10.0.0.0/24 via $1
+	ip -6 ro replace 1000::/120 via $PREFIX:$1
+	ip -6 ro replace $PREFIX:10.0.0.0/120 via $PREFIX:$1
+}
+
+cmd_tcase_start_tcpdump() {
+	local dev=eth1
+	test -n "$1" && dev=$1
+
+	tcase "Start tcpdump on dev=$1"
+	local pcap=/var/log/usrsctp-$(hostname)-$1.pcap
+	local cmd="tcpdump -i $dev sctp -w $pcap"
+	tlog $cmd
+	nohup $cmd 2>&1 &
+	# tcpdump takes a couple of seconds to start
+	sleep 2
+	tex "pgrep -P $$ tcpdump > /dev/null" || tdie
+}
+
+cmd_tcase_stop_all_tcpdump() {
+	tcase "Stop all instances of tcpdump"
+	local cmd="pkill tcpdump"
+	tlog $cmd
+	$cmd
+	tex "! pgrep tcpdump" || tdie
+}
+
+. /etc/profile
+. /usr/lib/xctest
+indent='  '
+
+
+# Get the command
+cmd=$1
+shift
+grep -q "^cmd_$cmd()" $0 || die "Invalid command [$cmd]"
+
+while echo "$1" | grep -q '^--'; do
+	if echo $1 | grep -q =; then
+		o=$(echo "$1" | cut -d= -f1 | sed -e 's,-,_,g')
+		v=$(echo "$1" | cut -d= -f2-)
+		eval "$o=\"$v\""
+	else
+		o=$(echo "$1" | sed -e 's,-,_,g')
+		eval "$o=yes"
+	fi
+	shift
+done
+unset o v
+long_opts=`set | grep '^__' | cut -d= -f1`
+
+# Execute command
+trap "die Interrupted" INT TERM
+cmd_$cmd "$@"
+status=$?
+rm -rf $tmp
+exit $status

--- a/ovl/usrsctp/default/etc/init.d/11xnet.rc
+++ b/ovl/usrsctp/default/etc/init.d/11xnet.rc
@@ -1,0 +1,61 @@
+#! /bin/sh
+. /usr/lib/network-topology.sh
+
+vm() {
+	ifsetup eth1 1
+	ifsetup eth2 2
+
+	ip ro add default via 192.168.1.201
+	ip -6 ro add default via $PREFIX:192.168.1.201
+
+	ip ru add oif eth2 table 300
+	ip ro add default via 192.168.2.202 table 300
+	ip -6 ru add oif eth2 table 301
+	ip -6 ro add default via $PREFIX:192.168.2.202 table 301
+
+	ip ro add 192.168.4.0/24 via 192.168.2.202
+	ip -6 ro add $PREFIX:192.168.4.0/120 via $PREFIX:192.168.2.202
+}
+
+router201() {
+	fwsetup
+	ifsetup eth1 1
+	ifsetup eth2 3
+	ip ro add default via 192.168.0.250
+	iptables -t nat -A POSTROUTING -s 192.168.1.0/24 -o eth0 -j MASQUERADE
+}
+
+router202() {
+	fwsetup
+	ifsetup eth1 2
+	ifsetup eth2 4
+	ip ro add default via 192.168.0.250
+}
+
+tester() {
+	ifsetup eth1 3
+	ifsetup eth2 4
+
+	ip ro add default via 192.168.3.201
+	ip -6 ro add default via $PREFIX:192.168.3.201
+	
+	ip ru add oif eth2 table 300
+	ip ro add default via 192.168.4.202 table 300
+	ip -6 ru add oif eth2 table 301
+	ip -6 ro add default via $PREFIX:192.168.4.202 table 301
+
+	ip ro add 192.168.2.0/24 via 192.168.4.202
+	ip -6 ro add $PREFIX:192.168.2.0/120 via $PREFIX:192.168.4.202
+}
+
+
+case $(hostname) in
+	vm-0*)
+		vm;;
+	vm-201)
+		router201;;
+	vm-202)
+		router202;;
+	vm-22*)
+		tester;;
+esac

--- a/ovl/usrsctp/default/etc/init.d/20usrsctp.rc
+++ b/ovl/usrsctp/default/etc/init.d/20usrsctp.rc
@@ -1,0 +1,33 @@
+#! /bin/sh
+
+. /etc/profile
+. /usr/lib/network-topology.sh
+
+vm() {
+	sysctl -w net.ipv4.conf.all.arp_announce=2
+	sysctl -w net.ipv4.conf.all.arp_ignore=1
+	sysctl -w net.ipv4.ip_nonlocal_bind=1
+	sysctl -w net.ipv6.ip_nonlocal_bind=1
+	sysctl -w net.ipv4.conf.all.proxy_arp=0
+
+	ip addr add 10.0.0.0/24 dev lo
+	ip -6 addr add 1000::/120 dev lo
+	ip -6 ro add local 1000::/120 dev lo
+}
+
+router() {
+	return 0
+}
+
+tester() {
+	return 0
+}
+
+case $(hostname) in
+    vm-0*)
+        vm;;
+    vm-20*)
+        router;;
+    vm-22*)
+        tester;;
+esac

--- a/ovl/usrsctp/default/etc/kubernetes/usrsctp/usrsctp-svc.yaml
+++ b/ovl/usrsctp/default/etc/kubernetes/usrsctp/usrsctp-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: usrsctp
+spec:
+  externalTrafficPolicy: Local
+  ipFamilyPolicy: PreferDualStack
+  selector:
+    app: usrsctp-test
+  ports:
+  - port: 7002
+    name: usrsctpt-server
+    protocol: SCTP
+  - port: 7003
+    name: usrsctpt-usrserver
+    protocol: SCTP
+  type: LoadBalancer

--- a/ovl/usrsctp/default/etc/kubernetes/usrsctp/usrsctp-test.yaml
+++ b/ovl/usrsctp/default/etc/kubernetes/usrsctp/usrsctp-test.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usrsctp-test
+spec:
+  selector:
+    matchLabels:
+      app: usrsctp-test
+  template:
+    metadata:
+      labels:
+        app: usrsctp-test
+    spec:
+      serviceAccount: default
+      nodeSelector:
+        kubernetes.io/hostname: vm-002
+      containers:
+      - name: usrsctp-test
+        imagePullPolicy: Always
+        image: registry.nordix.org/cloud-native/usrsctp-test:latest
+        ports:
+        - containerPort: 7002
+        - containerPort: 7003
+        securityContext:
+          privileged: true

--- a/ovl/usrsctp/image/Dockerfile
+++ b/ovl/usrsctp/image/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.nordix.org/cloud-native/xcluster-base:latest
+ADD --chown=0:0 ovl.tar /
+CMD ["/init"]

--- a/ovl/usrsctp/image/default/etc/init.d/42usrsctpt.rc
+++ b/ovl/usrsctp/image/default/etc/init.d/42usrsctpt.rc
@@ -1,0 +1,5 @@
+#! /bin/sh
+. /etc/profile
+test "$NO_SERVERS" = "yes" && exit 0
+#usrsctpt server --log=7 --addr=:: --port=7003 &
+usrsctpt niclient --log=7 --addr=192.168.3.221 --port=7003 --laddr=11.0.2.2

--- a/ovl/usrsctp/image/default/etc/init.d/99main.rc
+++ b/ovl/usrsctp/image/default/etc/init.d/99main.rc
@@ -1,0 +1,6 @@
+#! /bin/sh
+. /etc/profile
+test -n "$USRSCTP_CMD" || USRSCTP_CMD="tail -f /dev/null"
+echo "Executing [$USRSCTP_CMD]"
+exec $USRSCTP_CMD
+

--- a/ovl/usrsctp/image/tar
+++ b/ovl/usrsctp/image/tar
@@ -1,0 +1,24 @@
+#! /bin/sh
+# NOTE: A common pattern is to specify "-" (stdout) as out-file,
+#  so there must be NO log printouts to stdout!
+
+dir=$(dirname $0); dir=$(readlink -f $dir)
+tmp=/tmp/$USER/xcluster_$$
+die() {
+	echo "ERROR: $*" >&2
+	rm -rf $tmp
+	exit 1
+}
+log() {
+	echo "INFO: $*" >&2
+}
+
+test -n "$1" || die "No out-file"
+
+mkdir -p $tmp
+cp -R $dir/default/* $tmp
+
+cd $tmp
+tar cf "$1" *
+cd - > /dev/null
+rm -rf $tmp

--- a/ovl/usrsctp/network-topology/Envsettings
+++ b/ovl/usrsctp/network-topology/Envsettings
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+export __nvm=2
+export __nrouters=2
+export __ntesters=1
+export __nets_vm=0,1,2
+export __nets201=0,1,3
+export __nets202=0,2,4
+export __nets221=0,3,4
+export __mem201=128
+export __mem202=128
+
+if ip netns id | grep -q _xcluster; then
+	# Ensure bridges for net 3-4
+	for i in 3 4; do
+		if ! ip link show xcbr$i > /dev/null 2>&1; then
+			$XCLUSTER br_setup $i || echo "ERROR: could not create xcbr$i"
+		fi
+	done
+fi

--- a/ovl/usrsctp/src/Makefile
+++ b/ovl/usrsctp/src/Makefile
@@ -1,0 +1,77 @@
+##
+## Make usrsctpt, an SCTP test program
+##
+## Targets;
+##  help - This printout
+##  all (default) - Build the lib and the executable
+##  clean - Remove built files
+##
+## Beside the usual CFLAGS and LDFLAGS some usable variables;
+##  O - The output directory. Default /tmp/$USER/usrsctpt
+##  X - The executable.  Default $(O)/usrsctpt
+##
+## Examples;
+##  make -j8
+##  make -j8 clean
+##  make -j8 CFLAGS=-DSANITY_CHECK test
+##  make -j8 X=/tmp/usrsctpt/usrsctpt
+##  make -j8 O=.       # (you *can*, but don't do that!)
+##
+
+USRSCTPD ?= /tmp/$(USER)/usrsctp/usr/local
+O ?= /tmp/$(USER)/usrsctpt
+X ?= $(O)/usrsctpt/usrsctpt
+
+DIRS := $(O)/usrsctpt $(O)/lib/test
+SRC := $(wildcard usrsctpt/*.c lib/*.c)
+OBJ := $(SRC:%.c=$(O)/%.o)
+
+NFQLB_VER := 0.6.0
+NFQLB_AR := $(ARCHIVE)/nfqlb-$(NFQLB_VER).tar.xz
+NFQLB_DIR := $(O)/nfqlb-$(NFQLB_VER)
+
+$(O)/%.o : %.c
+	$(CC) -c $(CFLAGS) -pthread -Wall -I$(NFQLB_DIR)/include -I$(USRSCTPD)/include -Ilib $< -o $@
+
+.PHONY: all static
+all: $(NFQLB_DIR) $(X)
+static: $(NFQLB_DIR) $(X)
+static: LDFLAGS := -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
+
+$(X): $(OBJ)
+	$(CC) -o $(X) $(OBJ) $(LDFLAGS) -pthread -L$(NFQLB_DIR)/lib -L$(USRSCTPD)/lib -lnfqlb -lsctp -lusrsctp -lrt
+$(OBJ): | $(DIRS)
+
+.PHONY: test test_progs
+LIB_SRC := $(wildcard lib/*.c)
+LIB_OBJ := $(LIB_SRC:%.c=$(O)/%.o)
+$(O)/lib/test/% : lib/test/%.c
+	$(CC) $(CFLAGS) -Wall -Ilib -pthread $< $(LIB_OBJ) -o $@ -L$(NFQLB_DIR)/lib -lnfqlb
+TEST_SRC := $(wildcard lib/test/*-test.c)
+TEST_PROGS := $(TEST_SRC:%.c=$(O)/%)
+test_progs: $(TEST_PROGS)
+test: $(TEST_PROGS)
+	@$(foreach p,$(TEST_PROGS),echo $(p);$(p);)
+
+$(DIRS):
+	@mkdir -p $(DIRS)
+
+$(NFQLB_DIR): $(NFQLB_AR)
+	@mkdir -p $(O)
+	tar -C $(O) -xf $(NFQLB_AR)
+	@touch $(NFQLB_DIR)
+
+.PHONY: clean
+clean:
+	rm -rf $(X) $(OBJ)
+
+.PHONY: help
+help:
+	@grep '^##' $(lastword $(MAKEFILE_LIST)) | cut -c3-
+	@echo "Binary:"
+	@echo "  $(X)"
+
+.PHONY: ver
+ver:
+	@echo "NFQLB_VER=$(NFQLB_VER)"
+	@echo "NFQLB_DIR=$(NFQLB_DIR)"

--- a/ovl/usrsctp/src/lib/ipaddr.c
+++ b/ovl/usrsctp/src/lib/ipaddr.c
@@ -1,0 +1,94 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include "ipaddr.h"
+#include <log.h>
+#include <netdb.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+
+int parseAddress(char const* str, int port, struct sockaddr_in6* a)
+{
+	struct addrinfo hints = {0};
+	struct addrinfo* res;
+	hints.ai_flags = AI_NUMERICHOST | AI_V4MAPPED;
+	hints.ai_family = AF_INET6;
+	int rc = getaddrinfo(str, NULL, &hints, &res);
+	if (rc != 0) {
+		warning("%s [%s]\n", gai_strerror(rc), str);
+		return rc;
+	}
+
+	debug("Family %d, len %d\n", res->ai_family, res->ai_addrlen);
+	memcpy(a, res->ai_addr, res->ai_addrlen);
+	freeaddrinfo(res);
+	return 0;
+}
+
+int parseAddrs(char const* str, int port, struct sockaddr** addrs)
+{
+	int slen = strlen(str);
+	char tmp[slen+1];
+
+	// Get the array length
+	int len = 0;
+	char* addr;
+	strcpy(tmp, str);
+	for (addr = strtok(tmp, ","); addr != NULL; addr = strtok(NULL, ",")) {
+		len++;
+	}
+	if (len == 0)
+		return len;				/* Nothing to parse */
+
+	struct sockaddr_in6* res = calloc(len, sizeof(struct sockaddr_in6));
+	*addrs = (struct sockaddr*)res;
+	strcpy(tmp, str);
+	for (addr = strtok(tmp, ","); addr != NULL; addr = strtok(NULL, ",")) {
+		if (parseAddress(addr, port, res) != 0) {
+			free(*addrs);
+			*addrs = NULL;
+			return -1;
+		}
+		res->sin6_port = htons(port);
+		res++;
+	}
+	return len;
+}
+
+void printAddrs(char const* prefix, struct sockaddr const* addrs, int cnt)
+{
+	char addr[INET6_ADDRSTRLEN];
+	char const* res;
+	unsigned short port;
+	while (cnt-- > 0) {
+		switch (addrs->sa_family) {
+		case AF_INET: {
+			struct sockaddr_in const* a = (struct sockaddr_in const*)addrs;
+			port = ntohs(a->sin_port);
+			res = inet_ntop(AF_INET, &a->sin_addr, addr, INET6_ADDRSTRLEN);
+			addrs = (void*)addrs + sizeof(*a);
+			break;
+		}
+		case AF_INET6: {
+			struct sockaddr_in6 const* a = (struct sockaddr_in6 const*)addrs;
+			port = ntohs(a->sin6_port);
+			res = inet_ntop(AF_INET6, &a->sin6_addr, addr, INET6_ADDRSTRLEN);
+			addrs = (void*)addrs + sizeof(*a);
+			break;
+		}
+		default:
+			warning("Address family %d\n", addrs->sa_family);
+			res = NULL;
+			addrs++;
+		}
+		if (res == NULL) {
+			warning("inet_ntop %s\n", strerror(errno));
+		} else {
+			logf("%s%s,%d\n", prefix, res, port);
+		}
+	}
+}

--- a/ovl/usrsctp/src/lib/ipaddr.h
+++ b/ovl/usrsctp/src/lib/ipaddr.h
@@ -1,0 +1,21 @@
+#pragma once
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include <netinet/in.h>
+
+// parseAddress parses one address. IPv4 address is returned as
+// ipv4 mapped ipv6 address.
+// returns 0 - success
+int parseAddress(char const* str, int port, /*out*/struct sockaddr_in6* a);
+
+// parseAddrs parses a comma-separated list of ip addresses. IPv4
+// addresses are returned as ipv4 mapped ipv6 addresses.
+// returns the number of addresses or -1 if failed.
+int parseAddrs(char const* str, int port, /*out*/struct sockaddr** addrs);
+
+// printAddrs Print the ip addresses. Non-ip addresses will cause
+// unpredictable errors.
+void printAddrs(char const* prefix, struct sockaddr const* addrs, int cnt);

--- a/ovl/usrsctp/src/lib/log.c
+++ b/ovl/usrsctp/src/lib/log.c
@@ -1,0 +1,17 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include "log.h"
+#include <stdlib.h>
+
+int loglevel = 5;
+char const* loglevelarg = "5";
+FILE* logout = NULL;
+
+void loginit(FILE* out)
+{
+	logout = out;
+	loglevel = atoi(loglevelarg);
+}

--- a/ovl/usrsctp/src/lib/log.h
+++ b/ovl/usrsctp/src/lib/log.h
@@ -1,0 +1,23 @@
+#pragma once
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include <stdio.h>
+
+extern int loglevel;
+extern char const* loglevelarg;
+extern FILE* logout;
+
+void loginit(FILE* out);
+
+#define WARNING if(loglevel>=4)
+#define NOTICE if(loglevel>=5)
+#define INFO if(loglevel>=6)
+#define DEBUG if(loglevel>=7)
+#define logf(arg...) fprintf(logout, arg)
+#define warning(arg...) WARNING{logf(arg);}
+#define notice(arg...) NOTICE{logf(arg);}
+#define info(arg...) INFO{logf(arg);}
+#define debug(arg...) DEBUG{logf(arg);}

--- a/ovl/usrsctp/src/lib/stats.c
+++ b/ovl/usrsctp/src/lib/stats.c
@@ -1,0 +1,124 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include "stats.h"
+#include <string.h>
+#include <stdint.h>
+
+#define CNTINC(x) __atomic_add_fetch(&(x),1,__ATOMIC_RELAXED)
+#define CNTDEC(x) __atomic_sub_fetch(&(x),1,__ATOMIC_RELAXED)
+#define ATOMIC_LOAD(x) __atomic_load_n(&(x),__ATOMIC_RELAXED)
+#define ATOMIC_STORE(x,v) __atomic_store_n(&(x),v,__ATOMIC_RELAXED)
+
+static inline uint64_t toNanos(struct timespec const* t)
+{
+	return t->tv_sec * 1000000000 + t->tv_nsec;
+}
+// Diff in micro seconds
+static unsigned timeDiff(struct timespec const* a, struct timespec const* b)
+{
+	return (unsigned)((toNanos(a) - toNanos(b)) / 1000);
+}
+
+void stats_init(void* buffer, unsigned nBuckets, unsigned interval)
+{
+	struct Stats* stats = buffer;
+	ATOMIC_STORE(stats->sent, 0);
+	ATOMIC_STORE(stats->received, 0);
+	ATOMIC_STORE(stats->maxRtt, 0);
+	ATOMIC_STORE(stats->nBuckets, nBuckets);
+	ATOMIC_STORE(stats->interval, interval);
+	for (int i = 0; i < nBuckets; i++) {
+		ATOMIC_STORE(stats->buckets[i], 0);
+	}
+}
+
+void stats_packet_prepare(
+	struct timespec const* now, void* packet, unsigned len)
+{
+	if (len >= sizeof(struct timespec)) {
+		memcpy(packet, now, sizeof(struct timespec));
+	}
+}
+void stats_packet_sent(struct Stats* stats)
+{
+	CNTINC(stats->sent);
+}
+
+void stats_packet_record(
+	struct Stats* stats, struct timespec const* now,
+	void const* packet, unsigned len)
+{
+	CNTINC(stats->received);
+	if (len < sizeof(struct timespec))
+		return;
+	struct timespec const* sent = packet;
+	unsigned rtt = timeDiff(now, sent);
+	unsigned rttMS = rtt / 1000;
+	if (rttMS > stats->maxRtt)
+		ATOMIC_STORE(stats->maxRtt, rttMS);
+
+	// Update the histogram
+	if (stats->nBuckets < 1)
+		return;
+	if (rtt >= ((stats->nBuckets - 1) * stats->interval)) {
+		CNTINC(stats->buckets[stats->nBuckets - 1]);
+		return;					/* Last bucket or more */
+	}
+	for (int i = 0; i < (stats->nBuckets - 1); i++) {
+		if (rtt < ((i + 1) * stats->interval)) {
+			CNTINC(stats->buckets[i]);
+			return;
+		}
+	}
+}
+
+void stats_print(FILE* out, struct Stats const* stats)
+{
+	fprintf(out, "Sent:     %u\n", stats->sent);
+	fprintf(out, "Received: %u\n", stats->received);
+	fprintf(out, "MaxRTT:   %u\n", stats->maxRtt);
+	fprintf(out, "Interval: %u\n", stats->interval);
+	if (stats->nBuckets < 1)
+		return;
+
+	unsigned max = 0;
+	for (int i = 0; i < stats->nBuckets; i++) {
+		if (stats->buckets[i] > max)
+			max = stats->buckets[i];
+	}
+	if (max == 0)
+		max = 1;				/* Prevent divide by zero */
+
+	char bar[80];
+	memset(bar, '=', sizeof(bar));
+	for (int i = 0; i < stats->nBuckets; i++) {
+		unsigned l = stats->buckets[i] * 64 / max;
+		bar[l] = 0;
+		fprintf(out, "%6u |%s\n", stats->buckets[i], bar);
+		bar[l] = '=';
+	}
+}
+#define str(a) #a
+#define JUNSIGNED(x) "  \"%s\": %u,\n", str(x), stats->x
+void stats_print_json(FILE* out, struct Stats const* stats)
+{
+	fprintf(out, "{\n");
+	fprintf(out, JUNSIGNED(sent));
+	fprintf(out, JUNSIGNED(received));
+	fprintf(out, JUNSIGNED(maxRtt));
+	fprintf(out, JUNSIGNED(nBuckets));
+	fprintf(out, JUNSIGNED(interval));
+	fprintf(out, "  \"buckets\": [\n");
+	if (stats->nBuckets > 0) {
+		for (int i = 0; i < (stats->nBuckets - 1); i++) {
+			fprintf(out, "    %u,\n", stats->buckets[i]);
+		}
+		fprintf(out, "    %u\n", stats->buckets[stats->nBuckets - 1]);
+	}
+	fprintf(out, "  ]\n");
+	fprintf(out, "}\n");
+}
+

--- a/ovl/usrsctp/src/lib/stats.h
+++ b/ovl/usrsctp/src/lib/stats.h
@@ -1,0 +1,49 @@
+#pragma once
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include <stdio.h>
+#include <time.h>
+
+struct Stats {
+	unsigned sent;
+	unsigned received;
+	unsigned maxRtt;			/* In milli seconds */
+	/* Histogram */
+	unsigned nBuckets;
+	unsigned interval;			/* In micro seconds */
+	unsigned buckets[];
+};
+
+/*
+  Initiate the passed buffer. The length must be enough for the
+  buckets array i.e >= sizeof(struct Stats) + nBuckets * sizeof(unsigned)
+ */
+void stats_init(void* buffer, unsigned nBuckets, unsigned interval);
+
+/*
+  Prepare a packet for sending.
+ */
+void stats_packet_prepare(
+	struct timespec const* now, void* packet, unsigned len);
+
+/*
+  Report that a packet is sent. The "sent" counter is updated.
+ */
+void stats_packet_sent(struct Stats* stats);
+
+
+
+/*
+  Handle a received reply packet. The "received" counter and rtt stats
+  are updated.
+ */
+void stats_packet_record(
+	struct Stats* stats, struct timespec const* now, void const* packet, unsigned len);
+
+/* Print functions */
+void stats_print(FILE* out, struct Stats const* stats);
+void stats_print_json(FILE* out, struct Stats const* stats);
+

--- a/ovl/usrsctp/src/lib/test/throttler-test.c
+++ b/ovl/usrsctp/src/lib/test/throttler-test.c
@@ -1,0 +1,53 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include <throttler.h>
+#include <stdio.h>
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define D(x)
+#define Dx(x) x
+
+// White-box testing;
+struct Throttler {
+	uint64_t start;			/* Start time in nanos */
+	uint64_t interval;		/* Time between events in nS */
+	uint64_t offset;		/* Random offset to prevent synced sends */
+	unsigned events;		/* Event counter */
+};
+
+
+
+int
+main(int argc, char* argv[])
+{
+	srand(55);
+	struct timespec now = {0};
+	unsigned delay;
+	struct Throttler* t = throttler_create(&now, 1000.0);
+	D(printf("interval = %lu\n", t->interval));
+	assert(t->interval == 1000000);
+	delay = throttler_delay(t, &now);
+	D(printf("delay = %u\n", delay));
+	assert(delay == 587);
+	throttler_event(t);
+	delay = throttler_delay(t, &now);
+	D(printf("delay = %u\n", delay));
+	assert(delay == 1587);
+	now.tv_nsec += 1000000;
+	delay = throttler_delay(t, &now);
+	D(printf("delay = %u\n", delay));
+	assert(delay == 587);
+	now.tv_nsec += 1000000;
+	delay = throttler_delay(t, &now);
+	D(printf("delay = %u\n", delay));
+	assert(delay == 0);
+
+	
+	printf("=== throttler-test OK\n");
+	return 0;
+}

--- a/ovl/usrsctp/src/lib/throttler.c
+++ b/ovl/usrsctp/src/lib/throttler.c
@@ -1,0 +1,47 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include "throttler.h"
+#include <die.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+static inline uint64_t toNanos(struct timespec const* t)
+{
+	return t->tv_sec * 1000000000 + t->tv_nsec;
+}
+
+struct Throttler {
+	uint64_t start;				/* Start time in nanos */
+	uint64_t interval;			/* Time between events in nS */
+	uint64_t offset;			/* Random offset to prevent synced sends */
+	unsigned events;			/* Event counter */
+};
+
+struct Throttler* throttler_create(struct timespec const* now, float rate)
+{
+	struct Throttler* t = calloc(1, sizeof(struct Throttler));
+	if (t == NULL)
+		die("OOM\n");
+	t->start = toNanos(now);
+	t->interval = (uint64_t)(1e9 / rate);
+	t->offset = (uint64_t)rand() % t->interval;
+	return t;
+}
+
+unsigned throttler_delay(struct Throttler* t, struct timespec const* _now)
+{
+	uint64_t now = toNanos(_now);
+	uint64_t next = t->start + t->offset + t->events * t->interval;
+	if (next <= now)
+		return 0;
+	return (next - now) / 1000;
+}
+
+void throttler_event(struct Throttler* t)
+{
+	t->events++;
+}
+

--- a/ovl/usrsctp/src/lib/throttler.h
+++ b/ovl/usrsctp/src/lib/throttler.h
@@ -1,0 +1,22 @@
+#pragma once
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include <time.h>
+
+struct Throttler;
+
+struct Throttler* throttler_create(struct timespec const* now, float rate);
+
+/*
+  throttler_delay returns the delay in micro seconds until the next
+  event.
+ */
+unsigned throttler_delay(struct Throttler* t, struct timespec const* now);
+
+/*
+  throttler_event "consumes" an event.
+ */
+void throttler_event(struct Throttler* t);

--- a/ovl/usrsctp/src/usrsctpt/cmdClient.c
+++ b/ovl/usrsctp/src/usrsctpt/cmdClient.c
@@ -1,0 +1,139 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include <log.h>
+#include <ipaddr.h>
+#include <cmd.h>
+#include <die.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <string.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include <usrsctp.h>
+#define debug_printf_stack (void(*)(const char *, ...))printf
+
+#define MAXMSG (1024*16)
+#define SLEEP 1
+
+static int cmdNoInteractiveClient(int argc, char **argv)
+{
+	char const* addr = "::1";
+	char const* laddr = "::1";
+	char const* port = "6000";
+	char const* lport = "0";
+	char const* lencapport = "0";
+	struct Option options[] = {
+		{"help", NULL, 0,
+		 "client [options]\n"
+		 "  Start a client"},
+		{"log", &loglevelarg, 0, "Log level 0-7"},
+		{"addr", &addr, 0, "Server addresses (default ::1)"},
+		{"laddr", &laddr, 0, "Local addresses (default ::1)"},
+		{"port", &port, 0, "Port (default 6000)"},
+		{"lport", &lport, 0, "Local port (default 0)"},
+		{"lencapport", &lencapport, 0, "Local UDP encapsulation port (default 9899)"},
+		{0, 0, 0, 0}
+	};
+	(void)parseOptionsOrDie(argc, argv, options);
+	loginit(stderr);
+
+	if (atoi(port) == 0)
+		die("Invalid port [%s]\n", port);
+	struct sockaddr* addrs;
+	int cnt = parseAddrs(addr, atoi(port), &addrs);
+	if (cnt < 0)
+		die("Invalid addresses [%s]\n", addr);
+	struct sockaddr* laddrs;
+	int lcnt = parseAddrs(laddr, atoi(lport), &laddrs);
+	if (lcnt < 0)
+		die("Invalid local addresses [%s]\n", laddr);
+
+	usrsctp_init(atoi(lencapport), NULL, debug_printf_stack);
+#ifdef SCTP_DEBUG
+	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_ALL);
+#endif
+	usrsctp_sysctl_set_sctp_blackhole(2);
+	usrsctp_sysctl_set_sctp_no_csum_on_loopback(0);
+
+	struct socket* sock = usrsctp_socket(AF_INET6, SOCK_STREAM, IPPROTO_SCTP, NULL, NULL, 0, NULL);
+	if (sock == NULL)
+		die("usrsctp_socket %s\n", strerror(errno));
+
+	if (usrsctp_bindx(sock, laddrs, lcnt, SCTP_BINDX_ADD_ADDR) != 0)
+		die("usrsctp_bindx %s\n", strerror(errno));
+
+	if (usrsctp_connectx(sock, addrs, cnt, NULL) != 0)
+		die("usrsctp_connectx %s\n", strerror(errno));
+
+	INFO{
+		logf("Connected\n");
+		struct sockaddr* addrs;
+		int cnt;
+		cnt = usrsctp_getladdrs(sock, 0, &addrs);
+		if (cnt <= 0)
+			die("usrsctp_getladdrs %d\n", cnt);
+		logf("Local addresses\n");
+		printAddrs("  ", addrs, cnt);
+		usrsctp_freeladdrs(addrs);
+		cnt = usrsctp_getpaddrs(sock, 0, &addrs);
+		if (cnt <= 0)
+			die("usrsctp_getpaddrs %d\n", cnt);
+		logf("Primary peer addresses\n");
+		printAddrs("  ", addrs, cnt);
+		usrsctp_freepaddrs(addrs);		
+	}
+
+	char buffer[MAXMSG];
+	memset(&buffer, 0, sizeof(buffer));
+	ssize_t rc;
+
+	struct sctp_rcvinfo rcv_info;
+	unsigned int infotype;
+	socklen_t infolen = (socklen_t)sizeof(struct sctp_rcvinfo);
+	int flags = 0;
+
+	for (;;) {
+		printf("send> "); fflush(stdout);
+		if (fgets(buffer, sizeof(buffer), stdin) == NULL)
+			break;
+		rc = usrsctp_sendv(sock, buffer, strlen(buffer), NULL, 0, NULL, 0, SCTP_SENDV_NOINFO, 0);
+		if (rc < 0)
+			die("usrsctp_sendv %s\n", strerror(errno));
+		if (rc != (strlen(buffer)))
+			die("send incomplete %d expected %d\n", rc, strlen(buffer));
+
+		rc = usrsctp_recvv(sock, (void*)buffer, MAXMSG, NULL, NULL, &rcv_info, &infotype, &infolen, &flags);
+		if (rc < 0)
+			die("usrsctp_recvv %s\n", strerror(errno));
+		if (rc == 0) {
+			info("Connection closed\n");
+			break;
+		}
+		buffer[rc - 1] = 0;
+		printf("recv> %s\n", buffer); fflush(stdout);
+
+		if (strcmp(buffer, "quit") == 0 || strcmp(buffer, "exit") == 0) {
+			info("Shutting down connection");
+			break;
+		}
+	}
+
+	usrsctp_close(sock);
+	while (usrsctp_finish() != 0) {
+		sleep(SLEEP);
+	}
+	return 0;
+}
+
+__attribute__ ((__constructor__)) static void addCommands(void) {
+	addCmd("client", cmdNoInteractiveClient);
+}

--- a/ovl/usrsctp/src/usrsctpt/cmdNonInteractiveClient.c
+++ b/ovl/usrsctp/src/usrsctpt/cmdNonInteractiveClient.c
@@ -1,0 +1,135 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include <log.h>
+#include <ipaddr.h>
+#include <cmd.h>
+#include <die.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <string.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include <usrsctp.h>
+#define debug_printf_stack (void(*)(const char *, ...))printf
+
+#define MAXMSG (1024*16)
+#define SLEEP 1
+
+static int cmdNoInteractiveClient(int argc, char **argv)
+{
+	char const* addr = "::1";
+	char const* laddr = "::1";
+	char const* port = "6000";
+	char const* lport = "0";
+	char const* lencapport = "0";
+	struct Option options[] = {
+		{"help", NULL, 0,
+		 "niclient [options]\n"
+		 "  Start a client"},
+		{"log", &loglevelarg, 0, "Log level 0-7"},
+		{"addr", &addr, 0, "Server addresses (default ::1)"},
+		{"laddr", &laddr, 0, "Local addresses (default ::1)"},
+		{"port", &port, 0, "Port (default 6000)"},
+		{"lport", &lport, 0, "Local port (default 0)"},
+		{"lencapport", &lencapport, 0, "Local UDP encapsulation port (default 9899)"},
+		{0, 0, 0, 0}
+	};
+	(void)parseOptionsOrDie(argc, argv, options);
+	loginit(stderr);
+
+	if (atoi(port) == 0)
+		die("Invalid port [%s]\n", port);
+	struct sockaddr* addrs;
+	int cnt = parseAddrs(addr, atoi(port), &addrs);
+	if (cnt < 0)
+		die("Invalid addresses [%s]\n", addr);
+	struct sockaddr* laddrs;
+	int lcnt = parseAddrs(laddr, atoi(lport), &laddrs);
+	if (lcnt < 0)
+		die("Invalid local addresses [%s]\n", laddr);
+
+	usrsctp_init(atoi(lencapport), NULL, debug_printf_stack);
+#ifdef SCTP_DEBUG
+	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_ALL);
+#endif
+	usrsctp_sysctl_set_sctp_blackhole(2);
+	usrsctp_sysctl_set_sctp_no_csum_on_loopback(0);
+
+	struct socket* sock = usrsctp_socket(AF_INET6, SOCK_STREAM, IPPROTO_SCTP, NULL, NULL, 0, NULL);
+	if (sock == NULL)
+		die("usrsctp_socket %s\n", strerror(errno));
+
+	if (usrsctp_bindx(sock, laddrs, lcnt, SCTP_BINDX_ADD_ADDR) != 0)
+		die("usrsctp_bindx %s\n", strerror(errno));
+
+	if (usrsctp_connectx(sock, addrs, cnt, NULL) != 0)
+		die("usrsctp_connectx %s\n", strerror(errno));
+
+	INFO{
+		logf("Connected\n");
+		struct sockaddr* addrs;
+		int cnt;
+		cnt = usrsctp_getladdrs(sock, 0, &addrs);
+		if (cnt <= 0)
+			die("usrsctp_getladdrs %d\n", cnt);
+		logf("Local addresses\n");
+		printAddrs("  ", addrs, cnt);
+		usrsctp_freeladdrs(addrs);
+		cnt = usrsctp_getpaddrs(sock, 0, &addrs);
+		if (cnt <= 0)
+			die("usrsctp_getpaddrs %d\n", cnt);
+		logf("Primary peer addresses\n");
+		printAddrs("  ", addrs, cnt);
+		usrsctp_freepaddrs(addrs);		
+	}
+
+	char send_string[] = "It really doesn't matter";
+	char buffer[MAXMSG];
+	memset(&buffer, 0, sizeof(buffer));
+
+	ssize_t rc;
+	struct sctp_rcvinfo rcv_info;
+	unsigned int infotype;
+	socklen_t infolen = (socklen_t)sizeof(struct sctp_rcvinfo);
+	int flags = 0;
+
+	for (int i = 0; i < 100; i++) {
+		strncpy(buffer, send_string, strlen(send_string));
+		printf("send> %s\n", buffer); fflush(stdout);
+
+		rc = usrsctp_sendv(sock, buffer, strlen(buffer), NULL, 0, NULL, 0, SCTP_SENDV_NOINFO, 0);
+		if (rc < 0)
+			die("usrsctp_sendv %s\n", strerror(errno));
+		if (rc != (strlen(buffer)))
+			die("send incomplete %d expected %d\n", rc, strlen(buffer));
+
+		rc = usrsctp_recvv(sock, (void*)buffer, MAXMSG, NULL, NULL, &rcv_info, &infotype, &infolen, &flags);
+		if (rc < 0)
+			die("usrsctp_recvv %s\n", strerror(errno));
+		if (rc == 0) {
+			info("Connection closed\n");
+			break;
+		}
+		buffer[rc - 1] = 0;
+		printf("recv> %s\n", buffer); fflush(stdout);
+	}
+
+	usrsctp_close(sock);
+	while (usrsctp_finish() != 0) {
+		sleep(SLEEP);
+	}
+	return 0;
+}
+
+__attribute__ ((__constructor__)) static void addCommands(void) {
+	addCmd("niclient", cmdNoInteractiveClient);
+}

--- a/ovl/usrsctp/src/usrsctpt/cmdServer.c
+++ b/ovl/usrsctp/src/usrsctpt/cmdServer.c
@@ -1,0 +1,254 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include <log.h>
+#include <ipaddr.h>
+#include <cmd.h>
+#include <die.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <string.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include <usrsctp.h>
+#define debug_printf_stack (void(*)(const char *, ...))printf
+
+#define MAXMSG (1024*16)
+#define SLEEP 1
+
+static void* serverThread(void* arg);
+struct serverThreadArg {
+	struct socket *sock;
+};
+
+static int cmdServer(int argc, char **argv)
+{
+	struct socket *sock;
+	struct sctp_udpencaps encaps;
+	struct sctp_event event;
+	uint16_t event_types[] = {SCTP_ASSOC_CHANGE,
+	                          SCTP_PEER_ADDR_CHANGE,
+	                          SCTP_REMOTE_ERROR,
+	                          SCTP_SHUTDOWN_EVENT,
+	                          SCTP_ADAPTATION_INDICATION,
+	                          SCTP_PARTIAL_DELIVERY_EVENT};
+
+	char const* laddr = "::1";
+	char const* lport = "6000";
+	char const* lencapport = "0";
+	char const* rencapport = "0";
+	struct Option options[] = {
+		{"help", NULL, 0,
+		 "server [options]\n"
+		 "  Start a server"},
+		{"log", &loglevelarg, 0, "Log level 0-7"},
+		{"addr", &laddr, 0, "Numeric comma separated addresses (default ::1)"},
+		{"port", &lport, 0, "Port (default 6000)"},
+		{"lencapport", &lencapport, 0, "Local UDP encapsulation port (default 9899)"},
+		{"rencapport", &rencapport, 0, "Remote UDP encapsulation port (default 0 == disabled)"},
+		{0, 0, 0, 0}
+	};
+	(void)parseOptionsOrDie(argc, argv, options);
+	loginit(stderr);
+
+	if (atoi(lport) == 0)
+		die("Invalid port [%s]\n", lport);
+
+	warning("Usrserver; %s\n", __TIME__);
+	usrsctp_init(atoi(lencapport), NULL, debug_printf_stack);
+#ifdef SCTP_DEBUG
+	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_NONE);
+#endif
+	usrsctp_sysctl_set_sctp_blackhole(2);
+	usrsctp_sysctl_set_sctp_no_csum_on_loopback(0);
+
+	if ((sock = usrsctp_socket(AF_INET6, SOCK_STREAM, IPPROTO_SCTP, NULL, NULL, 0, NULL)) == NULL) {
+		die("usrsctp_socket");
+	}
+	warning("usrsctp_socket succesful; %p\n", sock);
+
+	const int on = 1;
+	if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_I_WANT_MAPPED_V4_ADDR, (const void*)&on, (socklen_t)sizeof(int)) < 0) {
+		die("usrsctp_setsockopt SCTP_I_WANT_MAPPED_V4_ADDR %s\n", strerror(errno));
+	}
+	if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_RECVRCVINFO, &on, (socklen_t)sizeof(int)) < 0) {
+		die("usrsctp_setsockopt SCTP_RECVRCVINFO %s\n", strerror(errno));
+	}
+	if (atoi(rencapport) != 0) {
+		memset(&encaps, 0, sizeof(struct sctp_udpencaps));
+		encaps.sue_address.ss_family = AF_INET6;
+		encaps.sue_port = htons(atoi(rencapport));
+		if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT, (const void*)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) < 0) {
+			perror("usrsctp_setsockopt SCTP_REMOTE_UDP_ENCAPS_PORT");
+		}
+	}
+	memset(&event, 0, sizeof(event));
+	event.se_assoc_id = SCTP_FUTURE_ASSOC;
+	event.se_on = 1;
+	
+	for (unsigned int i = 0; i < (unsigned int)(sizeof(event_types)/sizeof(uint16_t)); i++) {
+		event.se_type = event_types[i];
+		if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_EVENT, &event, sizeof(struct sctp_event)) < 0) {
+			perror("usrsctp_setsockopt SCTP_EVENT");
+		}
+	}
+	struct sockaddr* addrs;
+	int cnt = parseAddrs(laddr, atoi(lport), &addrs);
+	if (cnt <= 0)
+		die("Invalid (or no) addresses [%s]\n", laddr);
+	debug("cnt %d\n", cnt);
+
+	if (usrsctp_bindx(sock, addrs, 1, SCTP_BINDX_ADD_ADDR) < 0) {
+		die("usrsctp_bindx %s\n", strerror(errno));
+	}
+	if (usrsctp_listen(sock, 64) < 0) {
+		die("usrsctp_listen %s\n", strerror(errno));
+	}
+
+	INFO{
+		struct sockaddr* addrs;
+		int cnt = usrsctp_getladdrs(sock, 0, &addrs);
+		if (cnt <= 0)
+			die("usrsctp_getladdrs %d\n", cnt);
+		logf("Accepting connections on:\n");
+		printAddrs("  ", addrs, cnt);
+		usrsctp_freeladdrs(addrs);
+	}
+
+	for (;;) {
+		struct serverThreadArg* arg = calloc(1, sizeof(*arg));
+		struct sockaddr_in6 peer;
+		memset(&peer, 0, sizeof(peer));
+		socklen_t len = sizeof(peer);
+		arg->sock = usrsctp_accept(sock, (struct sockaddr*)&peer, &len);
+		if (arg->sock == NULL)
+			die("usrsctp_accept %s\n", strerror(errno));
+		INFO{
+			logf("Got a new connection (%p) from\n", arg->sock);
+			printAddrs("  ", (struct sockaddr*)&peer, 1);
+		}
+
+		if (cnt > 1) {
+			struct sockaddr_in6* laddrs;
+			laddrs = (struct sockaddr_in6*)((void*)addrs + sizeof(struct sockaddr_in6));
+			printAddrs("Adding secondary local addresses: ", (struct sockaddr*)laddrs, cnt - 1);
+			if (usrsctp_bindx(arg->sock, (struct sockaddr*)laddrs, cnt - 1, SCTP_BINDX_ADD_ADDR) != 0)
+				die("usrsctp_bindx %s\n", strerror(errno));
+		}
+
+		INFO{
+			struct sockaddr* addrs;
+			int cnt;
+			cnt = usrsctp_getladdrs(arg->sock, 0, &addrs);
+			if (cnt <= 0)
+				die("usrsctp_getladdrs %d\n", cnt);
+			logf("Local addresses\n");
+			printAddrs("  ", addrs, cnt);
+			usrsctp_freeladdrs(addrs);		
+		}
+
+		pthread_t tid;
+		if (pthread_create(&tid, NULL, serverThread, arg) != 0)
+			die("pthread_create\n");
+		if (pthread_detach(tid) != 0)
+			die("pthread_detach\n");
+	}
+
+	usrsctp_close(sock);
+	while (usrsctp_finish() != 0) {
+		sleep(SLEEP);
+	}
+	return 0;
+}
+
+static void* serverThread(void* _arg)
+{
+	struct serverThreadArg* arg = _arg;
+	INFO{
+		logf("serverThread (%p).\n", arg->sock);
+		struct sockaddr* addrs;
+		int cnt;
+		cnt = usrsctp_getladdrs(arg->sock, 0, &addrs);
+		if (cnt <= 0)
+			die("usrsctp_getladdrs %d\n", cnt);
+		logf("Local addresses\n");
+		printAddrs("  ", addrs, cnt);
+		usrsctp_freeladdrs(addrs);
+		cnt = usrsctp_getpaddrs(arg->sock, 0, &addrs);
+		if (cnt <= 0)
+			die("usrsctp_getpaddrs %d\n", cnt);
+		logf("Peer addresses\n");
+		printAddrs("  ", addrs, cnt);
+		usrsctp_freepaddrs(addrs);
+	}
+
+	for (;;) {
+		char buffer[MAXMSG];
+		char name[INET6_ADDRSTRLEN];
+		struct sockaddr_in6 addr;
+
+		struct sctp_rcvinfo rcv_info;
+		unsigned int infotype;
+
+		socklen_t from_len = (socklen_t)sizeof(struct sockaddr_in6);
+		int flags = 0;
+		socklen_t infolen = (socklen_t)sizeof(struct sctp_rcvinfo);
+		ssize_t n = usrsctp_recvv(arg->sock, (void*)buffer, MAXMSG, (struct sockaddr *) &addr, &from_len, (void *)&rcv_info,
+							&infolen, &infotype, &flags);
+		if (n > 0) {
+			if (flags & MSG_NOTIFICATION) {
+				printf("Notification of length %llu received.\n", (unsigned long long)n);
+			} else {
+				if (infotype == SCTP_RECVV_RCVINFO) {
+					printf("Msg of length %llu received from %s:%u on stream %u with SSN %u and TSN %u, PPID %u, context %u, complete %d.\n",
+							(unsigned long long)n,
+							inet_ntop(AF_INET6, &addr.sin6_addr, name, INET6_ADDRSTRLEN), ntohs(addr.sin6_port),
+							rcv_info.rcv_sid,
+							rcv_info.rcv_ssn,
+							rcv_info.rcv_tsn,
+							(uint32_t)ntohl(rcv_info.rcv_ppid),
+							rcv_info.rcv_context,
+							(flags & MSG_EOR) ? 1 : 0);
+					if (flags & MSG_EOR) {
+						struct sctp_sndinfo snd_info;
+
+						snd_info.snd_sid = rcv_info.rcv_sid;
+						snd_info.snd_flags = 0;
+						if (rcv_info.rcv_flags & SCTP_UNORDERED) {
+							snd_info.snd_flags |= SCTP_UNORDERED;
+						}
+						snd_info.snd_ppid = rcv_info.rcv_ppid;
+						snd_info.snd_context = 0;
+						snd_info.snd_assoc_id = rcv_info.rcv_assoc_id;
+						if (usrsctp_sendv(arg->sock, buffer, (size_t)n, NULL, 0, &snd_info, (socklen_t)sizeof(struct sctp_sndinfo), SCTP_SENDV_SNDINFO, 0) < 0) {
+							perror("sctp_sendv");
+						}
+					}
+				} else {
+					printf("Msg of length %llu received from %s:%u, complete %d.\n",
+							(unsigned long long)n,
+							inet_ntop(AF_INET6, &addr.sin6_addr, name, INET6_ADDRSTRLEN), ntohs(addr.sin6_port),
+							(flags & MSG_EOR) ? 1 : 0);
+				}
+			}
+		} else {
+			break;
+		}
+	}
+	
+	usrsctp_close(arg->sock);
+	return NULL;
+}
+
+
+__attribute__ ((__constructor__)) static void addCommands(void) {
+	addCmd("server", cmdServer);
+}

--- a/ovl/usrsctp/src/usrsctpt/main.c
+++ b/ovl/usrsctp/src/usrsctpt/main.c
@@ -1,0 +1,17 @@
+/*
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2021-2022 Nordix Foundation
+*/
+
+#include <cmd.h>
+#include <stdio.h>
+
+
+int main(int argc, char *argv[])
+{
+	// Make logs to stdout/stderr appear when output is redirected
+	setlinebuf(stdout);
+	setlinebuf(stderr);
+
+	return handleCmd(argc, argv);
+}

--- a/ovl/usrsctp/tar
+++ b/ovl/usrsctp/tar
@@ -1,0 +1,34 @@
+#! /bin/sh
+# NOTE: A common pattern is to specify "-" (stdout) as out-file,
+#  so there must be NO log printouts to stdout!
+
+dir=$(dirname $0); dir=$(readlink -f $dir)
+tmp=/tmp/$USER/xcluster_$$
+die() {
+	echo "ERROR: $*" >&2
+	rm -rf $tmp
+	exit 1
+}
+log() {
+	echo "INFO: $*" >&2
+}
+
+mkdir -p $tmp
+test -n "$1" || die "No out-file"
+cp -R $dir/default/* $tmp
+eval $(make -s -C $dir/src ver)
+nfqlb=$NFQLB_DIR/bin/nfqlb
+if test -x $nfqlb; then
+	log "Including nfqlb"
+	cp $nfqlb $tmp/bin
+else
+	log "Nfqlb not included"
+fi
+
+make -s -C $dir/src clean > /dev/null 2>&1
+make -s -C $dir/src -j$(nproc) X=$tmp/bin/usrsctpt static > /dev/null 2>&1 || die make
+
+cd $tmp
+tar cf "$1" *
+cd - > /dev/null
+rm -rf $tmp

--- a/ovl/usrsctp/usrsctp.sh
+++ b/ovl/usrsctp/usrsctp.sh
@@ -1,0 +1,166 @@
+#! /bin/sh
+##
+## sctp.sh --
+##
+##   Help script for the xcluster ovl/sctp.
+##
+## Commands;
+##
+
+prg=$(basename $0)
+dir=$(dirname $0); dir=$(readlink -f $dir)
+me=$dir/$prg
+tmp=/tmp/${prg}_$$
+
+die() {
+    echo "ERROR: $*" >&2
+    rm -rf $tmp
+    exit 1
+}
+help() {
+    grep '^##' $0 | cut -c3-
+    rm -rf $tmp
+    exit 0
+}
+test -n "$1" || help
+echo "$1" | grep -qi "^help\|-h" && help
+
+log() {
+	echo "$prg: $*" >&2
+}
+dbg() {
+	test -n "$__verbose" && echo "$prg: $*" >&2
+}
+
+##  env
+##    Print environment.
+##
+cmd_env() {
+
+	test -n "$__tag" || __tag="registry.nordix.org/cloud-native/usrsctp-test:latest"
+
+	if test "$cmd" = "env"; then
+		set | grep -E '^(__.*)='
+		return 0
+	fi
+
+	test -n "$xcluster_DOMAIN" || xcluster_DOMAIN=xcluster
+	test -n "$XCLUSTER" || die 'Not set [$XCLUSTER]'
+	test -x "$XCLUSTER" || die "Not executable [$XCLUSTER]"
+	eval $($XCLUSTER env)
+}
+
+##   test --list
+##   test [--xterm] [test...] > logfile
+##     Exec tests
+##
+cmd_test() {
+	if test "$__list" = "yes"; then
+        grep '^test_' $me | cut -d'(' -f1 | sed -e 's,test_,,'
+        return 0
+    fi
+
+	cmd_env
+    start=starts
+    test "$__xterm" = "yes" && start=start
+    rm -f $XCLUSTER_TMP/cdrom.iso
+
+    if test -n "$1"; then
+        for t in $@; do
+            test_$t
+        done
+    else
+		test_start
+    fi      
+
+    now=$(date +%s)
+    tlog "Xcluster test ended. Total time $((now-begin)) sec"
+
+}
+
+test_start() {
+	. ./network-topology/Envsettings
+
+	xcluster_prep
+	xcluster_start iptools network-topology usrsctp
+
+	otc 1 check_namespaces
+	otc 1 check_nodes
+	otc 221 start_server
+
+	otc 201 vip_ecmp_route
+	otc 202 "vip_ecmp_route 2"
+
+	otc 2 "start_tcpdump eth1"
+	otc 2 "start_tcpdump eth2"
+	otc 221 "start_tcpdump eth1"
+	otc 221 "start_tcpdump eth2"
+
+	otc 1 deploy_test_pods
+	tlog "Sleep for 30 seconds for the client to finish"
+	sleep 30
+	#otc 1 start_client_interactive
+
+	otc 2 stop_all_tcpdump
+	otc 221 stop_all_tcpdump
+
+	sleep 10
+
+	rcp 2 /var/log/*.pcap captures/
+	rcp 221 /var/log/*.pcap captures/
+}
+
+##   nfqlb_download
+##     Download a nfqlb release to $ARCHIVE
+cmd_nfqlb_download() {
+	eval $(make -s -C $dir/src ver)
+	local ar=nfqlb-$NFQLB_VER.tar.xz
+	local f=$ARCHIVE/$ar
+	if test -r $f; then
+		log "Already downloaded [$f]"
+	else
+		local url=https://github.com/Nordix/nfqueue-loadbalancer
+		curl -L $url/releases/download/$NFQLB_VER/$ar > $f
+	fi
+}
+
+##   mkimage [--tag=registry.nordix.org/cloud-native/sctp-test:latest]
+##     Create the docker image and upload it to the local registry.
+##
+cmd_mkimage() {
+	cmd_env
+	mkdir -p $dir/image/default/bin
+	make -C $dir/src clean
+	make -j$(nproc) -C $dir/src X=$dir/image/default/bin/usrsctpt static
+	local imagesd=$($XCLUSTER ovld images)
+	$imagesd/images.sh mkimage --force --upload --strip-host --tag=$__tag $dir/image
+}
+
+. $($XCLUSTER ovld test)/default/usr/lib/xctest
+indent=''
+
+# Get the command
+cmd=$1
+shift
+grep -q "^cmd_$cmd()" $0 $hook || die "Invalid command [$cmd]"
+
+while echo "$1" | grep -q '^--'; do
+    if echo $1 | grep -q =; then
+	o=$(echo "$1" | cut -d= -f1 | sed -e 's,-,_,g')
+	v=$(echo "$1" | cut -d= -f2-)
+	eval "$o=\"$v\""
+    else
+	o=$(echo "$1" | sed -e 's,-,_,g')
+	eval "$o=yes"
+    fi
+    shift
+done
+unset o v
+long_opts=`set | grep '^__' | cut -d= -f1`
+
+# Execute command
+trap "die Interrupted" INT TERM
+cmd_$cmd "$@"
+status=$?
+rm -rf $tmp
+exit $status


### PR DESCRIPTION
Test environment for
https://datatracker.ietf.org/doc/draft-porfiri-tsvwg-sctp-natsupp/

A copy of sctp ovl with some changes:
- Do not modprobe sctp kmod
- usrsctpt test tool for a minimal server/client based on https://github.com/sctplab/usrsctp
- Only K8s test with 2 VMs, 2 routers and a tester connected for a distributed SCTP client in k8s connected to the SCTP server in the tester VM in a multipath scenario
