### PR TITLE
"cdo" completion: Use ps -p $$ instead of /proc/$$/exe

### DIFF
--- a/Envsettings
+++ b/Envsettings
@@ -93,7 +93,7 @@ if ! netstat -lutan | grep -q :::10053; then
 fi
 
 # completion is a bash thing
-readlink -f /proc/$$/exe | grep -q bash || return 0
+ps -p $$ | grep -q bash || return 0
 test -n "$PS1" || return 0
 
 _cdo_completion() {


### PR DESCRIPTION
Some distros (I am using WSL2) don't allow accessing /proc using non-root users inside non-root network namespaces, ps -p seems a safer bet to check if we are running bash. Maybe this is just a problem with WSL2, anyhow it would be nice to fix this.

```
sriramy@DESKTOP-D5JSVGC-wsl:~/xc/xcluster$ readlink -f /proc/$$/exe
/usr/bin/bash
sriramy@DESKTOP-D5JSVGC-wsl:~/xc/xcluster$ echo $?
0
sriramy@DESKTOP-D5JSVGC-wsl:~/xc/xcluster$ exec ip netns exec sriramy_xcluster1 /bin/bash
bash-5.0$ readlink -f /proc/$$/exe
bash-5.0$ echo $?
1

```