### PR TITLE
Use the first IP address if there are more.

### DIFF
--- a/ovl/images/images.sh
+++ b/ovl/images/images.sh
@@ -257,7 +257,7 @@ cmd_lreg_preload() {
 
 ##
 cmd_get_regip() {
-	local regip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' registry)
+	local regip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{println .IPAddress}}{{end}}' registry | head -1)
 	test -n "$regip" || die "Can't get address of the local registry"
 	echo $regip
 }


### PR DESCRIPTION
Signed-off-by: Szilard Vincze <szilard.vincze@est.tech>

When we share the same local registry between xcluster and kind, images.sh does not work because it finds two IP addresses since kind connects the registry to its own network too.

With this fix, cmd_get_regip() will return only the first IP instead of two in a row and images.sh can be used for both xcluster and kind.