### PR TITLE
ovl/iptools; libbpf link to local kernel build

### DIFF
--- a/ovl/iptools/iptools.sh
+++ b/ovl/iptools/iptools.sh
@@ -115,6 +115,7 @@ build_iproute2() {
 	ar=$1.tar.xz
 	tar -C $XCLUSTER_WORKSPACE -xf $ARCHIVE/$ar || die tar
 	cd $d
+	./configure --libbpf_dir=$XCLUSTER_WORKSPACE/sys
 	make KERNEL_INCLUDE=$__kobj/sys/include || die make
 	make DESTDIR=$d/sys install || die "make install"
 	cd man

--- a/xcluster.sh
+++ b/xcluster.sh
@@ -431,9 +431,16 @@ cmd_iproute2_build() {
 		tar -C $(dirname $d) -xf $ar || die "Failed to unpack [$ar]"
 	fi
 
+	local kdir=$KERNELDIR/$__kver
+	test -d "$kdir" || die "Not a directory [$kdir]"
+	cd $kdir/tools/lib/bpf || die cd
+	make -j$(nproc) || die "Make libbpf"
+	make DESTDIR=$XCLUSTER_WORKSPACE/sys prefix=/usr install \
+		|| die "Make libbpf install sys"
+
 	if ! test -x $d/ip/ip; then
 		cd $d
-		./configure
+		./configure --libbpf_dir=$XCLUSTER_WORKSPACE/sys
 		KERNEL_INCLUDE=$__kobj/include \
 			make -j $(nproc) || die "Make iproute2 failed"
 	fi


### PR DESCRIPTION
iproute2 version > 5.17.0 requires libbpf from latest kernel version.

I hit some problems building iproute2 > 5.17.0, which seems to require latest libbpf versions. An attempt to fix that in xcluster.sh build scripts. 
Please review if this change is valid and required.