### PR TITLE
ovl/lldp; enable lldp forwarding by default

### DIFF
--- a/ovl/lldp/README.md
+++ b/ovl/lldp/README.md
@@ -1,17 +1,28 @@
 # Xcluster/ovl - lldp
 
-Experiments with lldpd.
+Experiments with Link Layer Discovery Protocol (LLDP)
 
 The [bridge](../network-topology#bridge) network topology is often used,
 but [xnet](../network-topology/#xnet) can also be used.
 
 <img src="../network-topology/bridge.svg" width="60%" />
 
-## Manual basic test
+The bridges on your host must [forward LLDP packets](
+https://interestingtraffic.nl/2017/11/21/an-oddly-specific-post-about-group_fwd_mask/).
+This is setup by default in `xcluster`.
+
+
+## Test
 
 Requirement; `xcluster` must be started in an own [netns](
 https://github.com/Nordix/xcluster/blob/master/doc/netns.md).
 
+```
+./lldp.sh    # Help printout
+./lldp.sh test neighbors > $log
+```
+
+Manual basic tests:
 ```
 cdo lldp
 ./lldp.sh test start_empty > $log

--- a/ovl/lldp/lldp.sh
+++ b/ovl/lldp/lldp.sh
@@ -69,32 +69,38 @@ cmd_test() {
 	rm -f $XCLUSTER_TMP/cdrom.iso
 
 	if test -n "$1"; then
-			local t=$1
-			shift
+		local t=$1
+		shift
 		test_$t $@
 	else
-			test_start
+		test_neighbors
 	fi
 
 	now=$(date +%s)
 	tlog "Xcluster test ended. Total time $((now-begin)) sec"
 }
 ##   test start_empty
-##     Start a cluster with xnet
+##     Start a cluster. TOPOLOGY=xnet|bridge. Xnet is default
 test_start_empty() {
+	test -n "$TOPOLOGY" || export TOPOLOGY=xnet
+	tlog "Using TOPOLOGY=$TOPOLOGY"
+	. $($XCLUSTER ovld network-topology)/$TOPOLOGY/Envsettings
 	export __image=$XCLUSTER_HOME/hd.img
 	echo "$XOVLS" | grep -q private-reg && unset XOVLS
 	test -n "$__ntesters" || export __ntesters=2
 	xcluster_start iptools network-topology . $@
 	otc 1 version
 }
-##   test start
-##      Start a cluster with xnet
-test_start() {
+##   test neighbors (default)
+##      Start a cluster and make some neighbor tests
+test_neighbors() {
+	export __nrouters=1
+	export __ntesters=2
 	test_start_empty
-	otc 1 "test_neighbors 5"
-	otc 201 "test_neighbors 5"
+	otc 1 "test_neighbors $__nvm"
+	otc 201 "test_neighbors $__nvm"
 	otc 221 "test_neighbors 1"
+	xcluster_stop
 }
 
 ##

--- a/ovl/network-topology/bridge/Envsettings
+++ b/ovl/network-topology/bridge/Envsettings
@@ -2,14 +2,3 @@
 
 export __nrouters=1
 export __mem201=128
-export __mem202=128
-
-br_opts='group_fwd_mask 0x4000'
-
-if ip netns id | grep -q _xcluster; then
-	# recreate bridges 1 and 2 with bridge forward options
-	for i in 1 2; do
-		ip link del xcbr$i > /dev/null 2>&1
-		$XCLUSTER br_setup $i "${br_opts}" || echo "ERROR: could not create xcbr$i"
-	done
-fi

--- a/ovl/vrf/README.md
+++ b/ovl/vrf/README.md
@@ -1,6 +1,6 @@
 # Xcluster/ovl - vrf
 
-Virtual Routing and Forwarding (VRF) and Link Layer Discovery Protocol (LLDP)
+Virtual Routing and Forwarding (VRF)
 
 * [linux/Documentation/networking/vrf.rst](
    https://docs.kernel.org/networking/vrf.html)

--- a/xcluster.sh
+++ b/xcluster.sh
@@ -308,8 +308,8 @@ set_netns_ipv4_addresses() {
 cmd_br_setup() {
 	test -n "$1" || die 'No index'
 	local i=$1
+	shift
 	local dev=xcbr$i
-	local br_opts=${2:-""}
 
 	if ip link show dev $dev > /dev/null 2>&1; then
 		log "Bridge already exists [$dev]"
@@ -317,7 +317,8 @@ cmd_br_setup() {
 	fi
 
 	test -n "$__mtu" || __mtu=1500
-	ip link add name $dev mtu $__mtu type bridge $br_opts || \
+	# https://interestingtraffic.nl/2017/11/21/an-oddly-specific-post-about-group_fwd_mask/
+	ip link add name $dev mtu $__mtu type bridge group_fwd_mask 0x4000 $@ || \
 		die "Failed to create bridge [$dev]"
 
 	ip link set $dev up


### PR DESCRIPTION
The "group_fwd_mask 0x4000" when creating bridges are made default.

The test is made scalable:
```
./lldp.sh test --nvm=10 neighbors > $log
```
