### PR TITLE
ovl/network-topology: set default __mem values only if not set

### DIFF
--- a/ovl/network-topology/backend/Envsettings
+++ b/ovl/network-topology/backend/Envsettings
@@ -3,8 +3,8 @@
 export __nrouters=2
 export __nets_vm=0,1,3
 export __nets_router=0,3,2
-export __mem201=128
-export __mem202=128
+test -n "$__mem201" || export __mem201=128
+test -n "$__mem202" || export __mem202=128
 
 
 if ip netns id | grep -q _xcluster; then

--- a/ovl/network-topology/bridge/Envsettings
+++ b/ovl/network-topology/bridge/Envsettings
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 export __nrouters=1
-export __mem201=128
+test -n "$__mem201" || export __mem201=128

--- a/ovl/network-topology/diamond/Envsettings
+++ b/ovl/network-topology/diamond/Envsettings
@@ -5,10 +5,10 @@ export __nets201=0,1,3,4
 export __nets202=0,2,5,6
 export __nets203=0,3,5
 export __nets204=0,4,6
-export __mem201=128
-export __mem202=128
-export __mem203=128
-export __mem204=128
+test -n "$__mem201" || export __mem201=128
+test -n "$__mem202" || export __mem202=128
+test -n "$__mem203" || export __mem203=128
+test -n "$__mem204" || export __mem204=128
 test -z "$__ntesters" && export __ntesters=1
 test $__ntesters -eq 0 && export __ntesters=1
 

--- a/ovl/network-topology/dual-path/Envsettings
+++ b/ovl/network-topology/dual-path/Envsettings
@@ -8,10 +8,11 @@ export __nets203=0,3,2
 export __nets204=0,5,6
 export __nets221=0,2,6
 export __nets222=0,2,6
-export __mem201=128
-export __mem202=128
-export __mem203=128
-export __mem204=128
+test -n "$__mem201" || export __mem201=128
+test -n "$__mem202" || export __mem202=128
+test -n "$__mem203" || export __mem203=128
+test -n "$__mem204" || export __mem204=128
+
 test -z "$__ntesters" && export __ntesters=2
 test $__ntesters -eq 0 && export __ntesters=2
 

--- a/ovl/network-topology/multihop/Envsettings
+++ b/ovl/network-topology/multihop/Envsettings
@@ -8,6 +8,9 @@ export __nets203=0,4,2
 export __mem201=128
 export __mem202=128
 export __mem203=128
+test -n "$__mem201" || export __mem201=128
+test -n "$__mem202" || export __mem202=128
+test -n "$__mem203" || export __mem203=128
 
 if ip netns id | grep -q _xcluster; then
 	# Ensure bridges for net 3-4

--- a/ovl/network-topology/multilan-router/Envsettings
+++ b/ovl/network-topology/multilan-router/Envsettings
@@ -2,8 +2,8 @@
 
 export __nrouters=2
 export __nets_vm=0,1,3,4,5
-export __mem201=128
-export __mem202=128
+test -n "$__mem201" || export __mem201=128
+test -n "$__mem202" || export __mem202=128
 export __nets202=0,1,2,3,4,5
 test -z "$__smp" -o "$__smp" -lt 3 && export __smp=3
 export __smp202=3

--- a/ovl/network-topology/multilan/Envsettings
+++ b/ovl/network-topology/multilan/Envsettings
@@ -2,8 +2,8 @@
 
 export __nrouters=2
 export __nets_vm=0,1,3,4,5
-export __mem201=128
-export __mem202=128
+test -n "$__mem201" || export __mem201=128
+test -n "$__mem202" || export __mem202=128
 export __smp1=3
 export __smp2=3
 export __smp3=3

--- a/ovl/network-topology/x-diamond/Envsettings
+++ b/ovl/network-topology/x-diamond/Envsettings
@@ -7,12 +7,13 @@ export __nets203=0,3,5,9,11
 export __nets204=0,4,6,9,12
 export __nets205=0,5,7,10,12
 export __nets206=0,6,8,10,11
-export __mem201=128
-export __mem202=128
-export __mem203=128
-export __mem204=128
-export __mem205=128
-export __mem206=128
+test -n "$__mem201" || export __mem201=128
+test -n "$__mem202" || export __mem202=128
+test -n "$__mem203" || export __mem203=128
+test -n "$__mem204" || export __mem204=128
+test -n "$__mem205" || export __mem205=128
+test -n "$__mem206" || export __mem206=128
+
 test -z "$__ntesters" && export __ntesters=1
 test $__ntesters -eq 0 && export __ntesters=1
 

--- a/ovl/network-topology/xnet/Envsettings
+++ b/ovl/network-topology/xnet/Envsettings
@@ -1,4 +1,4 @@
 #! /bin/sh
 # Only defaults are used for xnet
-export __mem201=128
-export __mem202=128
+test -n "$__mem201" || export __mem201=128
+test -n "$__mem202" || export __mem202=128

--- a/ovl/network-topology/zones/Envsettings
+++ b/ovl/network-topology/zones/Envsettings
@@ -3,9 +3,9 @@
 export __nets_vm=0,1
 export __nets_router=0,1,2,3,4
 export __smp201=3
-export __mem201=192
+test -n "$__mem201" || export __mem201=192
 export __smp202=3
-export __mem202=192
+test -n "$__mem202" || export __mem202=192
 export __nets10=0,3
 export __nets11=0,3
 export __nets12=0,3


### PR DESCRIPTION
Sourcing Envsettings.k8s sets larger defaults for __mem201 and __mem202, and using network-topology overwrites these defaults. This patch avoids that.