### PR TITLE
Include $xcluster_PREFIX when creating netns

### DIFF
--- a/ovl/test/default/usr/lib/xctest
+++ b/ovl/test/default/usr/lib/xctest
@@ -616,8 +616,9 @@ xcluster_start() {
 	# (mode set for backward compatibility)
 	__mode=dual-stack
 	export xcluster___mode=$__mode
+	test -n "$xcluster_PREFIX" || xcluster_PREFIX=$PREFIX
 	test -n "$xcluster_DOMAIN" || xcluster_DOMAIN=xcluster
-	export xcluster_DOMAIN
+	export xcluster_DOMAIN xcluster_PREFIX
 	test -n "$xcluster_KUBECONFIG" || xcluster_KUBECONFIG=/etc/kubernetes/kubeconfig.token
 	export xcluster_KUBECONFIG
 	test "$__no_start" = "yes" && return 0

--- a/xcluster.sh
+++ b/xcluster.sh
@@ -158,7 +158,7 @@ cmd_nsadd() {
 	ip -6 ro add $__ipv6_prefix$ipv4_ns/128 dev xcluster$1
 
 	ip link set host$1 netns $netns
-	sudo ip netns exec $netns \
+	sudo ip netns exec $netns env xcluster_PREFIX=$xcluster_PREFIX \
 		$me nssetup --ipv4-base=$__ipv4_base --ipv6-prefix=$__ipv6_prefix $1
 	sudo $me masq --ipv4-base=$__ipv4_base
 
@@ -178,7 +178,7 @@ cmd_nsadd_docker() {
 	cmd_docker_net $1
 
 	ip link set host$1 netns $netns
-	sudo ip netns exec $netns \
+	sudo ip netns exec $netns env xcluster_PREFIX=$xcluster_PREFIX \
 		$me nssetup --docker --adr4=$adr4 --gw4=$gw4 $1
 	mkrmtap
 }


### PR DESCRIPTION
### Why do we need it?

The ipv6 addresses on the xcluster bridges uses $xcluster_PREFIX, but that variable is lost when "sudo" is invoked. This means that the default `1000::1` is always used, which will not match the addresses in the VMs if another PREFIX is used.

And BTW, `1000::1` is not a good prefix, `fd00:` [is better](https://en.wikipedia.org/wiki/Unique_local_address).