### PR TITLE
ovl/iptools: upgrade to nft 1.0.7

### DIFF
--- a/ovl/iptools/README.md
+++ b/ovl/iptools/README.md
@@ -6,14 +6,14 @@ the latest iptools. The `ntf` program for configuring the
 included.
 
 
-Usage
------
+## Usage
 
 Prerequisite: The kernel must be built with nftables support.
 
 Build;
 
 ```
+./iptools.sh versions
 ./iptools.sh download
 ./iptools.sh build
 ```
@@ -26,22 +26,3 @@ xc mkcdrom iptools ...
 
 This overlay is almost always used with other overlays.
 
-Versions
---------
-
-```
-> ./iptools.sh versions
-libmnl=1.0.4
-libnftnl=1.0.9
-iptables=1.6.2
-nftables=0.8.3
-libnfnetlink=1.0.1
-libnetfilter_cttimeout=1.0.0
-libnetfilter_conntrack=1.0.6
-libnetfilter_cthelper=1.0.0
-libnetfilter_queue=1.0.3
-conntrack_tools=1.4.4
-libnl=1.1.4
-ipvsadm=1.26
-ipset=6.38
-```

--- a/ovl/iptools/tar
+++ b/ovl/iptools/tar
@@ -59,6 +59,9 @@ if which nmap > /dev/null; then
 	$XCLUSTER install_prog --dest=$tmp nmap ncat nping
 fi
 
+which hping3 > /dev/null && $XCLUSTER install_prog --dest=$tmp hping3
+
+
 d=$XCLUSTER_WORKSPACE/iproute2-$iproute2/sys
 test -d $d || die "Not a directory [$d]"
 log "Including iproute2-$iproute2..."


### PR DESCRIPTION
### Upgrade to latest nft

Not urgent, but I will work some with `nft` and would like to use the latest.

The shift .bz2 -> .xz makes this PR a bet more complex than expected. Also the `iptools.sh man` is updated so the man-pages for nft are included.

`hping3` is included if it exist on the host + some doc updates.