### PR TITLE
ovl/load-balancer: Honor PREFIX and use the configured kernel

### DIFF
--- a/ovl/load-balancer/default/etc/init.d/20load-balancer.rc
+++ b/ovl/load-balancer/default/etc/init.d/20load-balancer.rc
@@ -2,6 +2,7 @@
 
 export PATH="/bin:/sbin:/usr/bin:/usr/sbin"
 . /etc/profile
+test -n "$PREFIX" || PREFIX=1000::1
 
 die() {
     echo "$@"
@@ -41,10 +42,10 @@ router() {
 	ip ro delete default
 	if test "$TOPOLOGY" = "evil_tester"; then
 		ip ro add 50.0.0.0/16 via 192.168.3.222
-		ip -6 ro add 2000::/112 via 1000::1:192.168.3.222
+		ip -6 ro add 2000::/112 via $PREFIX:192.168.3.222
 	else
 		ip ro add 50.0.0.0/16 via 192.168.2.221
-		ip -6 ro add 2000::/112 via 1000::1:192.168.2.221
+		ip -6 ro add 2000::/112 via $PREFIX:192.168.2.221
 	fi
 }
 
@@ -55,7 +56,7 @@ evil_tester() {
 	sysctl -w net.ipv4.conf.all.forwarding=1
 	echo 1 > /proc/sys/net/ipv4/conf/all/accept_local
 	ip ro add 50.0.0.0/16 via 192.168.2.221
-	ip -6 ro add 2000::/112 via 1000::1:192.168.2.221
+	ip -6 ro add 2000::/112 via $PREFIX:192.168.2.221
 }
 
 tester() {

--- a/ovl/load-balancer/ecmp/etc/init.d/50ecmp.rc
+++ b/ovl/load-balancer/ecmp/etc/init.d/50ecmp.rc
@@ -2,6 +2,7 @@
 
 export PATH="/bin:/sbin:/usr/bin:/usr/sbin"
 . /etc/profile
+test -n "$PREFIX" || PREFIX=1000::1
 
 die() {
     echo "$@"
@@ -25,7 +26,7 @@ router() {
 	ip ro replace 10.0.0.0/24 $targets
 	targets=''
 	for i in $(seq 1 $__nvm); do
-		targets="$targets nexthop via 1000::1:192.168.1.$i"
+		targets="$targets nexthop via $PREFIX:192.168.1.$i"
 	done
 	ip -6 ro replace 1000::/120 $targets
 

--- a/ovl/load-balancer/load-balancer.sh
+++ b/ovl/load-balancer/load-balancer.sh
@@ -129,7 +129,6 @@ scale_lb() {
 # ecmp ----------------------------------------------------------------
 test_start_ecmp() {
 	export SETUP=ecmp
-	export __kver=linux-5.4.35
 	test_start
 }
 


### PR DESCRIPTION
Linux-5.4.35 was hard-coded to cover an ECMP problem that should be exposed

