### PR TITLE
ovl/load-balancer: Use resilient nexthop for ecmp

### DIFF
--- a/ovl/load-balancer/ecmp/etc/init.d/50ecmp.rc
+++ b/ovl/load-balancer/ecmp/etc/init.d/50ecmp.rc
@@ -20,14 +20,21 @@ router() {
 	test -n "$__nvm" || __nvm=4
 	local i targets
 	for i in $(seq 1 $__nvm); do
-		targets="$targets nexthop via 192.168.1.$i"
+		ip nexthop add id $i via 192.168.1.$i dev eth1
+		test -z "$targets" && targets="$i" || targets="$targets/$i"
 	done
-	ip ro replace 10.0.0.0/24 $targets
+	ip nexthop add id 100 group $targets type resilient \
+		buckets 8 idle_timer 60 unbalanced_timer 300
+	ip ro replace 10.0.0.0/24 nhid 100
 	targets=''
 	for i in $(seq 1 $__nvm); do
-		targets="$targets nexthop via 1000::1:192.168.1.$i"
+		j=$(( $i + 50 ))
+		ip -6 nexthop add id $j via 1000::1:192.168.1.$i dev eth1
+		test -z "$targets" && targets="$j" || targets="$targets/$j"
 	done
-	ip -6 ro replace 1000::/120 $targets
+	ip nexthop add id 101 group $targets type resilient \
+		buckets 8 idle_timer 60 unbalanced_timer 300
+	ip -6 ro replace 1000::/120 nhid 101
 
 	echo 0 > /proc/sys/net/ipv4/fib_multipath_hash_policy
 	echo 0 > /proc/sys/net/ipv6/fib_multipath_hash_policy


### PR DESCRIPTION
When multipath routes are used, changes in next-hop can cause reassignment of hash to path calculation as described in [0] and [1].

TLDR:
If a multipath group is used for load-balancing between multiple servers, this hash space reassignment causes an issue that packets from a single flow suddenly end up arriving at a server that does not expect them. This can result in TCP connections being reset.

If a multipath group is used for load-balancing among available paths to the same server, the issue is that different latencies and reordering along the way causes the packets to arrive in the wrong order, resulting in degraded application performance.

[0]: https://docs.kernel.org/networking/nexthop-group-resilient.html
[1]: https://netdevconf.info/0x15/papers/20/isea%20(4).pdf