### PR TITLE
Remove check for ovl/k8s-xcluster in k8s_build_images

### DIFF
--- a/ovl/k8s-cni-calico/tar
+++ b/ovl/k8s-cni-calico/tar
@@ -14,7 +14,7 @@ log() {
 }
 
 modmaster() {
-	local f=$($XCLUSTER ovld k8s-xcluster)/$1/etc/init.d/31kube-master.rc
+	local f=$($XCLUSTER ovld kubernetes)/$1/etc/init.d/31kube-master.rc
 	test -r $f || die "Not readable [$f]"
 	mkdir -p $tmp/etc/init.d
 	dst=$tmp/etc/init.d/31kube-master.rc

--- a/xcadmin.sh
+++ b/xcadmin.sh
@@ -314,8 +314,6 @@ cmd_k8s_build_images() {
 	$ovl/tar - > /dev/null || die "etcd/tar failed"
 	ovl="$($XCLUSTER ovld kubernetes)"
 	$ovl/tar - > /dev/null || die "kubernetes/tar failed"
-	ovl="$($XCLUSTER ovld k8s-xcluster)"
-	$ovl/tar - > /dev/null || die "k8s-xcluster/tar failed"
 
 	# Build the k8s-xcluster image;
 	local image


### PR DESCRIPTION
The check in `xcadmin.sh` for ovl/k8s-xcluster fails and must be removed
