### PR TITLE
ovl/network-topology: Allow >vm-099 and fix tests

### DIFF
--- a/ovl/network-topology/README.md
+++ b/ovl/network-topology/README.md
@@ -10,7 +10,7 @@ The maintenance network 0 (eth0) is alway setup but is not shown here.
 An addressing pattern is used. All VMs gets addresses as;
 
 ```
-PREFIX=1000::1
+PREFIX=fd00:
 ip addr add ethX 192.168.$net.$i
 ip -6 addr add ethX $PREFIX:192.168.$net.$i
 ```
@@ -40,6 +40,13 @@ Usually the number of VMs and testers can be scaled by setting `__nvm`
 and `__ntesters` but most setups must have a defined number of
 routers, so setting `__nrouters` should be avoided.
 
+Note that the settings in `$TOPOLOGY/Envsettings` must be included if
+you scaleout:
+
+```
+# For TOPOLOGY=multilan-router
+__nets_vm=0,1,3,4,5 xc scaleout 193
+```
 
 ## Test
 
@@ -83,8 +90,7 @@ For [PMTU](../mtu) and traceroute tests.
 
 The VMs are distributed to different networks. Since the VMs are not
 in a consecutive sequence the VMs in the "zones" must be
-scaled-out. Further the `xc stop` must be invoked with an option to
-ensure all VMs are stopped.
+scaled-out.
 
 ```
 export TOPOLOGY=zones
@@ -93,7 +99,7 @@ xc mkcdrom iptools network-topology ...
 xc starts
 xc scaleout 10 11 20 21
 # (do some testing...)
-xc stop --nvm=30
+xc stop
 ```
 
 ## Backend

--- a/ovl/network-topology/backend/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/backend/etc/init.d/11xnet.rc
@@ -25,10 +25,10 @@ tester() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-20*)
 		router;;
 	vm-22*)
 		tester;;
+	vm-*)
+		vm;;
 esac

--- a/ovl/network-topology/bridge/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/bridge/etc/init.d/11xnet.rc
@@ -27,10 +27,10 @@ tester() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-20*)
 		bridge;;
 	vm-22*)
 		tester;;
+	vm-*)
+		vm;;
 esac

--- a/ovl/network-topology/diamond/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/diamond/etc/init.d/11xnet.rc
@@ -61,8 +61,6 @@ tester() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-201)
 		router201;;
 	vm-202)
@@ -73,4 +71,6 @@ case $(hostname) in
 		router204;;
 	vm-22*)
 		tester;;
+	vm-*)
+		vm;;
 esac

--- a/ovl/network-topology/dual-path/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/dual-path/etc/init.d/11xnet.rc
@@ -113,8 +113,6 @@ tester() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-201)
 		router201;;
 	vm-202)
@@ -125,4 +123,6 @@ case $(hostname) in
 		router204;;
 	vm-22*)
 		tester;;
+	vm-*)
+		vm;;
 esac

--- a/ovl/network-topology/evil_tester/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/evil_tester/etc/init.d/11xnet.rc
@@ -55,12 +55,12 @@ tester222() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-20*)
 		router;;
 	vm-221)
 		tester221;;
 	vm-222)
 		tester222;;
+	vm-*)
+		vm;;
 esac

--- a/ovl/network-topology/multihop/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/multihop/etc/init.d/11xnet.rc
@@ -46,8 +46,6 @@ tester() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-201)
 		router201;;
 	vm-202)
@@ -56,4 +54,6 @@ case $(hostname) in
 		router203;;
 	vm-22*)
 		tester;;
+	vm-*)
+		vm;;
 esac

--- a/ovl/network-topology/multilan-router/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/multilan-router/etc/init.d/11xnet.rc
@@ -44,12 +44,12 @@ tester() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-20*)
 		router;;
 	vm-22*)
 		tester;;
+	vm-*)
+		vm;;
 esac
 
 
@@ -90,7 +90,7 @@ router_202() {
 }
 
 case $(hostname) in
-	vm-0*)
+	vm-0*|vm-1*)
 		vm_x;;
 	vm-202)
 		router_202;;

--- a/ovl/network-topology/multilan/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/multilan/etc/init.d/11xnet.rc
@@ -43,10 +43,10 @@ tester() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-20*)
 		router;;
 	vm-22*)
 		tester;;
+	vm-*)
+		vm;;
 esac

--- a/ovl/network-topology/network-topology.sh
+++ b/ovl/network-topology/network-topology.sh
@@ -180,9 +180,9 @@ test_multilan_router() {
 	tlog "=== network-topology test: $TOPOLOGY"
 	test_start
 	base_test
-	otc 202 "ping 169.254.2.1"
-	otc 202 "ping 169.254.3.2"
-	otc 202 "ping 169.254.4.3"
+	otc 202 "ping 169.254.3.1"
+	otc 202 "ping 169.254.4.2"
+	otc 202 "ping 169.254.5.3"
 	xcluster_stop
 }
 

--- a/ovl/network-topology/x-diamond/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/x-diamond/etc/init.d/11xnet.rc
@@ -89,8 +89,6 @@ tester() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-201)
 		router201;;
 	vm-202)
@@ -105,4 +103,6 @@ case $(hostname) in
 		router206;;
 	vm-22*)
 		tester;;
+	vm-*)
+		vm;;
 esac

--- a/ovl/network-topology/xnet/etc/init.d/11xnet.rc
+++ b/ovl/network-topology/xnet/etc/init.d/11xnet.rc
@@ -47,10 +47,10 @@ tester() {
 
 
 case $(hostname) in
-	vm-0*)
-		vm;;
 	vm-20*)
 		router;;
 	vm-22*)
 		tester;;
+	vm-*)
+		vm;;
 esac


### PR DESCRIPTION
The setup scripts matched on vm-0* which excluded the range vm-100--vm-199 as valid VMs. Also some minor test and doc fixes