### PR TITLE
Don't re-unpack the cdrom on reboot

### DIFF
--- a/image/rootfs/init
+++ b/image/rootfs/init
@@ -22,13 +22,16 @@ mdev -s
 mount /dev/mqueue
 mount -t cgroup2 cgroup2 /sys/fs/cgroup
 
-# Get data from cdrom
-mkdir -p /mnt
-if mount -t iso9660 /dev/vdb /mnt > /dev/null 2>&1; then
-	for n in $(find /mnt -name '*.tar' | sort); do
-		EXTRACT_UNSAFE_SYMLINKS=1 tar -C / -o -xf $n
-	done
-	umount /mnt
+if ! test -r /run/initialboot; then
+	date > /run/initialboot
+	# Get data from cdrom
+	mkdir -p /mnt
+	if mount -t iso9660 /dev/vdb /mnt > /dev/null 2>&1; then
+		for n in $(find /mnt -name '*.tar' | sort); do
+			EXTRACT_UNSAFE_SYMLINKS=1 tar -C / -o -xf $n
+		done
+		umount /mnt
+	fi
 fi
 
 sysctl -p > /dev/null


### PR DESCRIPTION
Nothing exotic, just:

```sh
if ! test -r /run/initialboot; then
	date > /run/initialboot
```
IMHO, this is better than out-calls from the VMs to qemu. A test that _wants_ a re-unpack can delete the file.


Fixes #53

