### PR TITLE
Add vm stop/reset commands with file system sync

### DIFF
--- a/config/busybox-1.36.1
+++ b/config/busybox-1.36.1
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.36.1
-# Fri Jul 28 12:56:40 2023
+# Mon Sep 11 09:40:06 2023
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -324,8 +324,8 @@ CONFIG_FEATURE_STAT_FORMAT=y
 CONFIG_FEATURE_STAT_FILESYSTEM=y
 CONFIG_STTY=y
 # CONFIG_SUM is not set
-# CONFIG_SYNC is not set
-# CONFIG_FEATURE_SYNC_FANCY is not set
+CONFIG_SYNC=y
+CONFIG_FEATURE_SYNC_FANCY=y
 # CONFIG_FSYNC is not set
 # CONFIG_TAC is not set
 CONFIG_TAIL=y


### PR DESCRIPTION
Adds functions for stop qemu emulation and reset+continue. The intention is for test-cases that tests things while a VM is away (rebooting). Since xcluster VMs reboot in about 1s, the procedure should be;
```
xc stop_vm 2
# Do some testing
xc reset_vm 2
# Do some more testing when the VM is back
```
The file systems are synced to prevent corruption as described in issue #58.
