### PR TITLE
Unified k8s image

### DIFF
--- a/ovl/k8s-cni-bridge/default/etc/init.d/26bridge.rc
+++ b/ovl/k8s-cni-bridge/default/etc/init.d/26bridge.rc
@@ -13,8 +13,18 @@ i=$(hostname | cut -d- -f2 | sed -re 's,^0+,,')
 test $i -le 200 || exit 0
 test -n "$PREFIX" || PREFIX=1000::1
 
-
-if ! grep -q CNI_INFO /etc/profile; then
+# The prefered way to suspress the default bridge CNI-plugin is to set
+# $CNI_INFO, either with xcluster_CNI_INFO, or in a script loaded
+# before before this script. As a fallback for backward compatibility
+# we check the precense of known start files for other CNI-plugins
+if test -n "$CNI_INFO"; then
+	echo "$CNI_INFO" | grep -qi bridge || exit 0
+else
+	test -r /etc/kubernetes/load/antrea.yaml \
+		-o -r /etc/init.d/20calico-prep.rc \
+		-o -r /etc/init.d//etc/init.d/25cilium-prep.rc \
+		-o -r /etc/init.d/25ovs-cni.rc \
+		-o -r /etc/init.d/20xcluster-cni-prep.rc && exit 1
 	echo CNI_INFO=bridge >> /etc/profile
 fi
 

--- a/ovl/k8s-cni-bridge/default/etc/init.d/26bridge.rc
+++ b/ovl/k8s-cni-bridge/default/etc/init.d/26bridge.rc
@@ -22,8 +22,9 @@ if test -n "$CNI_INFO"; then
 else
 	test -r /etc/kubernetes/load/antrea.yaml \
 		-o -r /etc/init.d/20calico-prep.rc \
-		-o -r /etc/init.d//etc/init.d/25cilium-prep.rc \
+		-o -r /etc/init.d/25cilium-prep.rc \
 		-o -r /etc/init.d/25ovs-cni.rc \
+		-o -r /etc/kubernetes/load/kube-flannel.yaml \
 		-o -r /etc/init.d/20xcluster-cni-prep.rc && exit 1
 	echo CNI_INFO=bridge >> /etc/profile
 fi

--- a/ovl/k8s-cni-calico/README.md
+++ b/ovl/k8s-cni-calico/README.md
@@ -98,29 +98,6 @@ mv -f calico-new.yaml calico-orig.yaml
 ```
 
 
-## Build [obsolete]
-
-Build an image with dual-stack and calico pre-pulled;
-```
-ver=v3.22.1
-docker pull calico/cni:$ver
-docker pull calico/node:$ver
-docker pull calico/kube-controllers:$ver
-docker pull calico/pod2daemon-flexvol:$ver
-images make coredns nordixorg/mconnect:v1.2 library/alpine:3.8 \
-  calico/cni:$ver calico/node:$ver calico/kube-controllers:$ver calico/pod2daemon-flexvol:$ver
-#export KUBERNETESD=$ARCHIVE/kubernetes/server/bin
-export __image=$XCLUSTER_WORKSPACE/xcluster/hd-k8s-xcluster-cni-calico.img
-cp $XCLUSTER_WORKSPACE/xcluster/hd.img $__image
-xc ximage xnet etcd iptools k8s-xcluster mconnect images coredns k8s-cni-calico
-# Test;
-export XCTEST_HOOK=$($XCLUSTER ovld k8s-xcluster)/xctest-hook
-export __nvm=5
-t=test-template
-$($XCLUSTER ovld $t)/$t.sh test basic_dual > /dev/null
-```
-
-
 ## Doc/check
 
 In no particular order.

--- a/ovl/k8s-cni-calico/k8s-cni-calico.sh
+++ b/ovl/k8s-cni-calico/k8s-cni-calico.sh
@@ -75,7 +75,6 @@ cmd_test() {
 ##   test start_empty
 ##     Start empty cluster. K8s nodes will be "NotReady".
 test_start_empty() {
-	export __image=$XCLUSTER_HOME/hd-k8s-xcluster.img
 	test -n "$xcluster_CALICO_BACKEND" || export xcluster_CALICO_BACKEND=none
 	tlog "CALICO_BACKEND=$xcluster_CALICO_BACKEND"
 	test -n "$TOPOLOGY" && \

--- a/ovl/k8s-cni-xcluster/README.md
+++ b/ovl/k8s-cni-xcluster/README.md
@@ -5,69 +5,7 @@ Use the [xcluster-cni](https://github.com/Nordix/xcluster-cni) CNI-plugin.
 ## Usage
 
 ```
-images lreg_upload --strip-host registry.nordix.org/cloud-native/xcluster-cni:latest
-export __image=$XCLUSTER_WORKSPACE/xcluster/hd-k8s-xcluster.img
-export XOVLS="k8s-cni-xcluster private-reg"
-export __nvm=5
+images lreg_preload k8s-cni-xcluster
 xc mkcdrom k8s-cni-xcluster; xc starts
 ```
 
-## Release
-
-```
-ver=v0.1.0
-docker tag registry.nordix.org/cloud-native/xcluster-cni:latest registry.nordix.org/cloud-native/xcluster-cni:$ver
-docker push registry.nordix.org/cloud-native/xcluster-cni:latest
-docker push registry.nordix.org/cloud-native/xcluster-cni:$ver
-cd $GOPATH/src/github.com/Nordix/xcluster-cni
-git tag $ver
-git push origin $ver
-```
-
-## SIT tunnels
-
-```
-sed -i -e 's,"None","sit",' $GOPATH/src/github.com/Nordix/xcluster-cni/xcluster-cni.yaml
-xc mkcdrom k8s-cni-xcluster; xc starts
-# On cluster;
-kubectl apply -f /etc/kubernetes/alpine.yaml
-kubectl get pods -o wide
-```
-
-Create a netns;
-```
-# On vm-004;
-ip netns add ns1
-ip link add name ns0 type veth peer name ns1
-ip link set ns0 netns ns1
-ip link set ns1 up
-ip addr add 40.0.0.0/31 dev ns1
-ip netns exec ns1 ip link set ns0 up
-ip netns exec ns1 ip addr add 40.0.0.1/31 dev ns0
-ip netns exec ns1 ip ro add default via 40.0.0.0
-ping -c1 -W1 40.0.0.1
-ip link set up dev sit0
-# On vm-003;
-ip link set up dev sit0
-ip ro add 40.0.0.0/31 dev sit0 onlink via 192.168.1.4 src 192.168.1.3
-ping -c1 -W1 40.0.0.1
-```
-
-Without k8s;
-```
-export __image=$XCLUSTER_WORKSPACE/xcluster/hd.img
-unset XOVLS
-xc mkcdrom xnet; xc starts
-# On vm-003;
-ip link set up dev tunl0
-ip link set up dev sit0
-ip addr add 20.0.0.3/32 dev sit0
-ip route add 20.0.0.4/32 dev sit0 onlink via 192.168.1.4
-tcpdump -ni eth1
-# On vm-004;
-ip link set up dev tunl0
-ip link set up dev sit0
-ip addr add 20.0.0.4/32 dev sit0
-ip route add 20.0.0.3/32 dev sit0 onlink via 192.168.1.3
-ping -c1 -W1 20.0.0.3
-```

--- a/ovl/mtu/README.md
+++ b/ovl/mtu/README.md
@@ -57,7 +57,6 @@ __k8sver=v1.18.3 ./xcadmin.sh k8s_test --cni=xcluster mtu > $log
 Manual;
 ```
 export __mtu=9000
-export __image=$XCLUSTER_WORKSPACE/xcluster/hd-k8s-xcluster.img
 export __nvm=5
 export __mem=1536
 export XOVLS="k8s-cni-xcluster private-reg"

--- a/xcadmin.sh
+++ b/xcadmin.sh
@@ -347,7 +347,6 @@ cmd_k8s_test() {
 	eval $($XCLUSTER env | grep XCLUSTER_HOME)
 	if test -n "$__cni"; then
 		# Test with k8s-xcluster;
-		__image=$XCLUSTER_HOME/hd-k8s-xcluster-$__k8sver.img
 		test -r $__image || __image=$XCLUSTER_HOME/hd-k8s-xcluster.img
 		test "$__cni" != "None" && export XOVLS="k8s-cni-$__cni private-reg $XXOVLS"
 		export __cni


### PR DESCRIPTION
After retirement of "ovl/k8s-xcluster" there is no need to have two k8s images.

The update in this PR should be backward compatible since the "hd-k8s-xcluster-k8sver.img" is created as a hard-link.
```
cd $XCLUSTER_WORKSPACE/xcluster
ll -i hd-k8s-master.img hd-k8s-xcluster-master.img
20972268 -rw-rw-r-- 4 jenkins uablrek 847M Sep 17 09:20 hd-k8s-master.img
20972268 -rw-rw-r-- 4 jenkins uablrek 847M Sep 17 09:20 hd-k8s-xcluster-master.img
```
same i-node.