### PR TITLE
ovl/private-reg: Use registries.conf

### DIFF
--- a/Envsettings
+++ b/Envsettings
@@ -92,6 +92,9 @@ if ! netstat -lutan | grep -q :::10053; then
 	unset cdns cdnslog
 fi
 
+alias images="$(readlink -f .)/ovl/images/images.sh"
+test -n "$__dns_spoof" || export __dns_spoof=$(readlink -f .)/config/dns-spoof.txt
+
 # completion is a bash thing
 ps -p $$ | grep -q bash || return 0
 test -n "$PS1" || return 0

--- a/Envsettings.k8s
+++ b/Envsettings.k8s
@@ -28,9 +28,6 @@ curl -L \$armurl/xcluster/images/hd-k8s.img.xz | xz -d > \$__image
 
 EOF
 
-alias images="$(readlink -f .)/ovl/images/images.sh"
-test -n "$__dns_spoof" || export __dns_spoof=$(readlink -f .)/config/dns-spoof.txt
-
 mynetns=$(ip netns id)
 if test -z "$KUBECONFIG"; then
 	if test -n "$mynetns"; then

--- a/ovl/private-reg/default/etc/init.d/28private-reg.rc
+++ b/ovl/private-reg/default/etc/init.d/28private-reg.rc
@@ -5,9 +5,18 @@ for a in $(grep -v '^#' /etc/spoofed-hosts | cut -d' ' -f1 | sort | uniq); do
 	ip ro replace $a via 192.168.0.250
 done
 
-grep -qE '^insecure_registries' /etc/crio/crio.conf && exit 0
-sed -i '/\[crio.image\]/a\
-insecure_registries = [\
- "%localreg%/16",\
- "192.168.0.0/24"\
-]' /etc/crio/crio.conf
+mkdir -p "/etc/containers"
+conf="/etc/containers/registries.conf"
+
+echo > $conf
+echo "unqualified-search-registries = ['%localreg%']" >> $conf
+echo "" >> $conf
+echo "[[registry]]" >> $conf
+echo "insecure = true" >> $conf
+echo "location = '%localreg%'" >> $conf
+echo "" >> $conf
+for reg in $(grep -v '^#' /etc/spoofed-hosts | cut -d' ' -f2 | sort | uniq); do
+	echo "[[registry]]" >> $conf
+	echo "insecure = true" >> $conf
+	echo "location = '$reg'" >> $conf
+done

--- a/ovl/private-reg/tar
+++ b/ovl/private-reg/tar
@@ -15,22 +15,11 @@ log() {
 
 test -n "$1" || die "No out-file"
 
-# Get the address to the local registry
-regip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' registry) \
-	|| die "Can't get address of the local registry"
-test -n "$regip" || die 'Address empty'
-#log "Address [$regip]"
-
 mkdir -p $tmp
-for s in $(echo "$SETUP" | tr ',' ' '); do
-	test -d $dir/$s || continue
-	cp -R $dir/$s/* $tmp
-	setup_copied=yes
-done
-test "$setup_copied" != "yes" && test -d $dir/default && cp -R $dir/default/* $tmp
+cp -R $dir/default/* $tmp
 
-sed -i -e "s,%localreg%,$regip," $tmp/etc/init.d/28private-reg.rc
 dip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' registry)
+sed -i -e "s,%localreg%,$dip," $tmp/etc/init.d/28private-reg.rc
 echo "$dip example.com" >> $tmp/etc/spoofed-hosts
 if test -n "$__dns_spoof"; then
 	test -r "$__dns_spoof" || die "Not readable [$__dns_spoof]"


### PR DESCRIPTION
Also move default dns_spoof settings to Envsettings, this prepares xcluster to be used for testing container networking without k8s.