### PR TITLE
Envsettings: Add an "lso" function

### DIFF
--- a/Envsettings
+++ b/Envsettings
@@ -113,3 +113,19 @@ _xc_completion() {
 	COMPREPLY=($($XCLUSTER completion $2))
 }
 complete -F _xc_completion xc
+
+lso() {
+	local d arg
+	for d in $(echo $XCLUSTER_OVLPATH | tr : '\n' | sort -u); do
+		arg="$arg $d/*"
+	done
+	if echo $@ | grep -qF -- '-t'; then
+		\ls -dt $arg | sed -E 's,.*/([^/]+),\1,'
+	else
+		if test -t 1 -o "$1" = '-c'; then
+			\ls -d $arg | sed -E 's,.*/([^/]+),\1,' | sort -u | column
+		else
+			\ls -d $arg | sed -E 's,.*/([^/]+),\1,' | sort -u 
+		fi
+	fi
+}


### PR DESCRIPTION
Works as "cdo \<tab>\<tab>" but you can "grep" the output:
```
lso | grep -i calico
```

Here is a similar function, with a twist. I tend to forget what I was working with at times. The function below lists ovls in "most recent touched" order, use for instance with `lsot | head -10`. I didn't include it to avoid implying that others are as demented as I :smile: 

```sh
lsot() {
	local d arg
	for d in $(echo $XCLUSTER_OVLPATH | tr : '\n' | sort | uniq); do
		arg="$arg $d/*"
	done
	ls -dt $arg
}
```