### PR TITLE
ovl/images: fix hanging getimages

### DIFF
--- a/ovl/images/images.sh
+++ b/ovl/images/images.sh
@@ -229,6 +229,7 @@ cmd_getimages() {
 		d=$($XCLUSTER ovld $1)
 		test -n "$d" || return 1
 	fi
+	find $d -name '*.yaml' | grep -q yaml || return 0
 	grep -hs ' image:' $(find $d -name '*.yaml') | sort | uniq | sed -E 's,.*image: *,,' | tr -d "\"'"
 }
 ##   lreg_preload [--force] [--keep-going] <dir/ovl>


### PR DESCRIPTION
"images getimages" hang if there are no images. It should just exit
