### PR TITLE
ovl/k8s-cni-calico: updrade to v3.26.4

### DIFF
--- a/ovl/k8s-cni-calico/README.md
+++ b/ovl/k8s-cni-calico/README.md
@@ -6,34 +6,27 @@ Use [project calico](https://www.projectcalico.org/) in
 Calico has currently 3 data-planes:
 
 * linux - the traditional Calico data-plane
-* epbf - A eBPF based data-plane ([only ipv4 for now](
+* epbf - A eBPF based data-plane ([no dual-stack support](
          https://github.com/projectcalico/calico/issues/4736))
 * vpp - A VPP user-space data-plane (not working yet in xcluster)
 
-The installation can also be made with manifests or the `Tigera operator`.
+The installation can be made with manifests or the `Tigera operator`.
 
 
 
 ## Usage
 
-Pre-load the private registry if needed;
-```
-cdo k8s-cni-calico
-images lreg_preload default
-# If the Tigera operator is used;
-ver=v3.24.5
-images lreg_cache docker.io/calico/pod2daemon-flexvol:$ver
-images lreg_cache docker.io/calico/typha:$ver
-images lreg_cache docker.io/calico/apiserver:$ver
-```
-
-The easiest way to use Calico is to start with `xcadmin`. This will
-use the "linux" data-plane.
+The easiest way to use Calico is to include this ovl, start with
+`xcadmin` or add it to the start command. This will use the "linux"
+data-plane.
 
 ```
+images lreg_preload k8s-cni-calico
 xcadmin k8s_test --cni=calico test-template > $log
+# or
+cdo test-template
+./test-template.sh test basic k8s-cni-calico > $log
 ```
-
 
 ## Data-planes
 
@@ -59,17 +52,29 @@ flag.
 
 ```
 ./k8s-cni-calico.sh        # Help printout
-./k8s-cni-calico.sh test start_bpf k8s-test > $log
-xcadmin k8s_test --no-start k8s-test > $log
-# VPP doesn't work yet
-./k8s-cni-calico.sh test start_vpp k8s-test > $log
+./k8s-cni-calico.sh test start_bpf test-template > $log
+xcadmin k8s_test --no-start test-template > $log
+# VPP
+./k8s-cni-calico.sh test start_vpp test-template > $log
+xcadmin k8s_test --no-start test-template > $log
+```
+
+Extra pre-loads needed by the operator and vpp:
+```
+ver=v3.26.4
+images lreg_cache docker.io/calico/pod2daemon-flexvol:$ver
+images lreg_cache docker.io/calico/typha:$ver
+images lreg_cache docker.io/calico/node-driver-registrar:$ver
+images lreg_cache docker.io/calico/csi:$ver
+images lreg_cache docker.io/calicovpp/agent:v3.26.0
+images lreg_cache docker.io/calicovpp/vpp:v3.26.0
 ```
 
 While testing out configurations it may be best to start manually.
 
 ```
 #export xcluster_PROXY_MODE=disabled
-#__xterm=yes __mem=2G __mem1=1G __nvm=3 \
+#__xterm=yes __mem=2G __mem1=3G __nvm=3 \
 ./k8s-cni-calico.sh test start_empty > $log
 # On vm-001:
 /etc/kubernetes/init.d/50calico.sh   # help printout
@@ -85,16 +90,23 @@ upgrade to newer versions.
 
 ```
 cdo k8s-cni-calico
-curl -L -o calico-new.yaml https://raw.githubusercontent.com/projectcalico/calico/release-v3.25/manifests/calico.yaml
+src=https://raw.githubusercontent.com/projectcalico/calico/release-v3.26/manifests
+curl -L -o calico-orig.yaml $src/calico.yaml
+cp calico-orig.yaml calico-new.yaml
 # Check the xcluster specific config. (3-way diff)
 meld calico-orig.yaml default/etc/kubernetes/calico/calico.yaml calico-new.yaml &
 # apply the modifications and save.
 cp calico-new.yaml default/etc/kubernetes/calico/calico.yaml
 # Cache images
 images lreg_preload default
-# Test!! And if everything works;
-mv -f calico-new.yaml calico-orig.yaml
-# Commit updates
+# Test!! And if everything works; Commit updates
+
+# Other manifests
+dst=./default/etc/kubernetes/calico/
+for m in calicoctl.yaml tigera-operator.yaml custom-resources.yaml; do
+  curl -L -o $dst/$m $src/$m
+done
+curl -L -o $dst/calico-vpp-nohuge.yaml https://raw.githubusercontent.com/projectcalico/vpp-dataplane/release/v3.26.0/yaml/generated/calico-vpp-nohuge.yaml
 ```
 
 
@@ -103,13 +115,9 @@ mv -f calico-new.yaml calico-orig.yaml
 In no particular order.
 
 * https://docs.projectcalico.org/v3.8/networking/ipv6
-
 * https://docs.projectcalico.org/v3.8/reference/felix/configuration
-
-* https://docs.projectcalico.org/v3.8/getting-started/calicoctl/install
-
+* https://docs.tigera.io/calico/latest/operations/calicoctl/install
 * https://projectcalico.docs.tigera.io/reference/installation/api
-
 * https://www.server-world.info/en/note?os=Scientific_Linux_6&p=kvm&f=8
 
 ```

--- a/ovl/k8s-cni-calico/calico-orig.yaml
+++ b/ovl/k8s-cni-calico/calico-orig.yaml
@@ -29,6 +29,13 @@ metadata:
   name: calico-node
   namespace: kube-system
 ---
+# Source: calico/templates/calico-node.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+---
 # Source: calico/templates/calico-config.yaml
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -149,6 +156,12 @@ spec:
                       type: string
                   type: object
                 type: array
+              ignoredInterfaces:
+                description: IgnoredInterfaces indicates the network interfaces that
+                  needs to be excluded when reading device routes.
+                items:
+                  type: string
+                type: array
               listenPort:
                 description: ListenPort is the port where BGP protocol should listen.
                   Defaults to 179
@@ -268,6 +281,130 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: bgpfilters.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPFilter
+    listKind: BGPFilterList
+    plural: bgpfilters
+    singular: bgpfilter
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPFilterSpec contains the IPv4 and IPv6 filter rules of
+              the BGP Filter.
+            properties:
+              exportV4:
+                description: The ordered set of IPv4 BGPFilter rules acting on exporting
+                  routes to a peer.
+                items:
+                  description: BGPFilterRuleV4 defines a BGP filter rule consisting
+                    a single IPv4 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+              exportV6:
+                description: The ordered set of IPv6 BGPFilter rules acting on exporting
+                  routes to a peer.
+                items:
+                  description: BGPFilterRuleV6 defines a BGP filter rule consisting
+                    a single IPv6 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+              importV4:
+                description: The ordered set of IPv4 BGPFilter rules acting on importing
+                  routes from a peer.
+                items:
+                  description: BGPFilterRuleV4 defines a BGP filter rule consisting
+                    a single IPv4 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+              importV6:
+                description: The ordered set of IPv6 BGPFilter rules acting on importing
+                  routes from a peer.
+                items:
+                  description: BGPFilterRuleV6 defines a BGP filter rule consisting
+                    a single IPv6 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: bgppeers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -302,6 +439,11 @@ spec:
                 description: The AS Number of the peer.
                 format: int32
                 type: integer
+              filters:
+                description: The ordered set of BGPFilters applied on this BGP peer.
+                items:
+                  type: string
+                type: array
               keepOriginalNextHop:
                 description: Option to keep the original nexthop field when routes
                   are sent to a BGP Peer. Setting "true" configures the selected BGP
@@ -367,12 +509,23 @@ spec:
                   remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
                   or the global default if that is not set.
                 type: string
+              reachableBy:
+                description: Add an exact, i.e. /32, static route toward peer IP in
+                  order to prevent route flapping. ReachableBy contains the address
+                  of the gateway which peer can be reached by.
+                type: string
               sourceAddress:
                 description: Specifies whether and how to configure a source address
                   for the peerings generated by this BGPPeer resource.  Default value
                   "UseNodeIP" means to configure the node IP as the source address.  "None"
                   means not to configure a source address.
                 type: string
+              ttlSecurity:
+                description: TTLSecurity enables the generalized TTL security mechanism
+                  (GTSM) which protects against spoofed packets by ignoring received
+                  packets with a smaller than expected TTL value. The provided value
+                  is the number of hops (edges) between the peers.
+                type: integer
             type: object
         type: object
     served: true
@@ -837,6 +990,13 @@ spec:
                   connections.  The only reason to disable it is for debugging purposes.  [Default:
                   true]'
                 type: boolean
+              bpfDSROptoutCIDRs:
+                description: BPFDSROptoutCIDRs is a list of CIDRs which are excluded
+                  from DSR. That is, clients in those CIDRs will accesses nodeports
+                  as if BPFExternalServiceMode was set to Tunnel.
+                items:
+                  type: string
+                type: array
               bpfDataIfacePattern:
                 description: BPFDataIfacePattern is a regular expression that controls
                   which interfaces Felix should attach BPF programs to in order to
@@ -857,9 +1017,10 @@ spec:
                   [Default: false]'
                 type: boolean
               bpfEnforceRPF:
-                description: 'BPFEnforceRPF enforce strict RPF on all interfaces with
-                  BPF programs regardless of what is the per-interfaces or global
-                  setting. Possible values are Disabled or Strict. [Default: Strict]'
+                description: 'BPFEnforceRPF enforce strict RPF on all host interfaces
+                  with BPF programs regardless of what is the per-interfaces or global
+                  setting. Possible values are Disabled, Strict or Loose. [Default:
+                  Loose]'
                 type: string
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
@@ -898,6 +1059,14 @@ spec:
                   minimum time between updates to the dataplane for Felix''s embedded
                   kube-proxy.  Lower values give reduced set-up latency.  Higher values
                   reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                type: string
+              bpfL3IfacePattern:
+                description: BPFL3IfacePattern is a regular expression that allows
+                  to list tunnel devices like wireguard or vxlan (i.e., L3 devices)
+                  in addition to BPFDataIfacePattern. That is, tunnel interfaces not
+                  created by Calico, that Calico workload traffic flows over as well
+                  as any interfaces that handle incoming traffic to nodeports and
+                  services from outside the cluster.
                 type: string
               bpfLogLevel:
                 description: 'BPFLogLevel controls the log level of the BPF programs
@@ -974,11 +1143,12 @@ spec:
                   to use.  Only used if UseInternalDataplaneDriver is set to false.
                 type: string
               dataplaneWatchdogTimeout:
-                description: 'DataplaneWatchdogTimeout is the readiness/liveness timeout
-                  used for Felix''s (internal) dataplane driver. Increase this value
+                description: "DataplaneWatchdogTimeout is the readiness/liveness timeout
+                  used for Felix's (internal) dataplane driver. Increase this value
                   if you experience spurious non-ready or non-live events when Felix
                   is under heavy load. Decrease the value to get felix to report non-live
-                  or non-ready more quickly. [Default: 90s]'
+                  or non-ready more quickly. [Default: 90s] \n Deprecated: replaced
+                  by the generic HealthTimeoutOverrides."
                 type: string
               debugDisableLogDropping:
                 type: boolean
@@ -1082,15 +1252,21 @@ spec:
                   type: object
                 type: array
               featureDetectOverride:
-                description: FeatureDetectOverride is used to override the feature
-                  detection. Values are specified in a comma separated list with no
-                  spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
-                  "true" or "false" will force the feature, empty or omitted values
-                  are auto-detected.
+                description: FeatureDetectOverride is used to override feature detection
+                  based on auto-detected platform capabilities.  Values are specified
+                  in a comma separated list with no spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".  "true"
+                  or "false" will force the feature, empty or omitted values are auto-detected.
+                type: string
+              featureGates:
+                description: FeatureGates is used to enable or disable tech-preview
+                  Calico features. Values are specified in a comma separated list
+                  with no spaces, example; "BPFConnectTimeLoadBalancingWorkaround=enabled,XyZ=false".
+                  This is used to enable features that are not fully production ready.
                 type: string
               floatingIPs:
                 description: FloatingIPs configures whether or not Felix will program
-                  floating IP addresses.
+                  non-OpenStack floating IP addresses.  (OpenStack-derived floating
+                  IPs are always programmed, regardless of this setting.)
                 enum:
                 - Enabled
                 - Disabled
@@ -1107,6 +1283,23 @@ spec:
                 type: string
               healthPort:
                 type: integer
+              healthTimeoutOverrides:
+                description: HealthTimeoutOverrides allows the internal watchdog timeouts
+                  of individual subcomponents to be overridden.  This is useful for
+                  working around "false positive" liveness timeouts that can occur
+                  in particularly stressful workloads or if CPU is constrained.  For
+                  a list of active subcomponents, see Felix's logs.
+                items:
+                  properties:
+                    name:
+                      type: string
+                    timeout:
+                      type: string
+                  required:
+                  - name
+                  - timeout
+                  type: object
+                type: array
               interfaceExclude:
                 description: 'InterfaceExclude is a comma-separated list of interfaces
                   that Felix should exclude when monitoring for host endpoints. The
@@ -1148,9 +1341,15 @@ spec:
                 type: string
               iptablesBackend:
                 description: IptablesBackend specifies which backend of iptables will
-                  be used. The default is legacy.
+                  be used. The default is Auto.
                 type: string
               iptablesFilterAllowAction:
+                type: string
+              iptablesFilterDenyAction:
+                description: IptablesFilterDenyAction controls what happens to traffic
+                  that is denied by network policy. By default Calico blocks traffic
+                  with an iptables "DROP" action. If you want to use "REJECT" action
+                  instead you can configure it in here.
                 type: string
               iptablesLockFilePath:
                 description: 'IptablesLockFilePath is the location of the iptables
@@ -4162,7 +4361,7 @@ rules:
     resources:
       - serviceaccounts/token
     resourceNames:
-      - calico-node
+      - calico-cni-plugin
     verbs:
       - create
   # The CNI plugin needs to get pods, nodes, and namespaces.
@@ -4179,7 +4378,7 @@ rules:
     resources:
       - endpointslices
     verbs:
-      - watch 
+      - watch
       - list
   - apiGroups: [""]
     resources:
@@ -4233,6 +4432,7 @@ rules:
       - globalfelixconfigs
       - felixconfigurations
       - bgppeers
+      - bgpfilters
       - globalbgpconfigs
       - bgpconfigurations
       - ippools
@@ -4316,6 +4516,41 @@ rules:
     verbs:
       - get
 ---
+# Source: calico/templates/calico-node-rbac.yaml
+# CNI cluster role
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-cni-plugin
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      - clusterinformations
+      - ippools
+      - ipreservations
+      - ipamconfigs
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+---
 # Source: calico/templates/calico-kube-controllers-rbac.yaml
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4342,6 +4577,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: calico-node
+  namespace: kube-system
+---
+# Source: calico/templates/calico-node-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-cni-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-cni-plugin
+subjects:
+- kind: ServiceAccount
+  name: calico-cni-plugin
   namespace: kube-system
 ---
 # Source: calico/templates/calico-node.yaml
@@ -4390,7 +4639,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.24.5
+          image: docker.io/calico/cni:v3.26.4
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4418,7 +4667,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.24.5
+          image: docker.io/calico/cni:v3.26.4
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4461,7 +4710,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.24.5
+          image: docker.io/calico/node:v3.26.4
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4487,7 +4736,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.24.5
+          image: docker.io/calico/node:v3.26.4
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4704,7 +4953,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.24.5
+          image: docker.io/calico/kube-controllers:v3.26.4
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/ovl/k8s-cni-calico/default/etc/kubernetes/calico/calico-vpp-nohuge.yaml
+++ b/ovl/k8s-cni-calico/default/etc/kubernetes/calico/calico-vpp-nohuge.yaml
@@ -72,6 +72,7 @@ rules:
   - globalfelixconfigs
   - felixconfigurations
   - bgppeers
+  - bgpfilters
   - globalbgpconfigs
   - bgpconfigurations
   - ippools
@@ -135,8 +136,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  service_prefix: 12.0.0.0/16
-  vpp_config_template: |-
+  CALICOVPP_CONFIG_TEMPLATE: |-
     unix {
       nodaemon
       full-coredump
@@ -161,8 +161,30 @@ data:
     buffers {
       buffers-per-numa 131072
     }
-  vpp_dataplane_interface: eth1
-  vpp_uplink_driver: "af_packet"
+  CALICOVPP_INITIAL_CONFIG: |-
+    {
+      "vppStartupSleepSeconds": 1,
+      "corePattern": "/var/lib/vpp/vppcore.%e.%p"
+    }
+  CALICOVPP_INTERFACES: |-
+    {
+      "maxPodIfSpec": {
+        "rx": 10, "tx": 10, "rxqsz": 1024, "txqsz": 1024
+      },
+      "defaultPodIfSpec": {
+        "rx": 1, "tx":1, "isl3": true
+      },
+      "vppHostTapSpec": {
+        "rx": 1, "tx":1, "rxqsz": 1024, "txqsz": 1024, "isl3": false
+      },
+      "uplinkInterfaces": [
+        {
+          "interfaceName": "eth1",
+          "vppDriver": "af_packet"
+        }
+      ]
+    }
+  SERVICE_PREFIX: 10.96.0.0/12
 kind: ConfigMap
 metadata:
   name: calico-vpp-config
@@ -194,14 +216,19 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: SERVICE_PREFIX
+        - name: NAMESPACE
           valueFrom:
-            configMapKeyRef:
-              key: service_prefix
-              name: calico-vpp-config
-        image: docker.io/calicovpp/agent:v3.24.0
+            fieldRef:
+              fieldPath: metadata.namespace
+        envFrom:
+        - configMapRef:
+            name: calico-vpp-config
+        image: docker.io/calicovpp/agent:v3.26.0
         imagePullPolicy: IfNotPresent
         name: agent
+        resources:
+          requests:
+            cpu: 250m
         securityContext:
           privileged: true
         volumeMounts:
@@ -217,28 +244,6 @@ spec:
           mountPropagation: Bidirectional
           name: netns
       - env:
-        - name: CALICOVPP_NATIVE_DRIVER
-          valueFrom:
-            configMapKeyRef:
-              key: vpp_uplink_driver
-              name: calico-vpp-config
-        - name: CALICOVPP_IP_CONFIG
-          value: linux
-        - name: CALICOVPP_INTERFACE
-          valueFrom:
-            configMapKeyRef:
-              key: vpp_dataplane_interface
-              name: calico-vpp-config
-        - name: CALICOVPP_CONFIG_TEMPLATE
-          valueFrom:
-            configMapKeyRef:
-              key: vpp_config_template
-              name: calico-vpp-config
-        - name: SERVICE_PREFIX
-          valueFrom:
-            configMapKeyRef:
-              key: service_prefix
-              name: calico-vpp-config
         - name: DATASTORE_TYPE
           value: kubernetes
         - name: WAIT_FOR_DATASTORE
@@ -247,11 +252,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: CALICOVPP_CORE_PATTERN
-          value: /var/lib/vpp/vppcore.%e.%p
-        image: docker.io/calicovpp/vpp:v3.24.0
+        envFrom:
+        - configMapRef:
+            name: calico-vpp-config
+        image: docker.io/calicovpp/vpp:v3.26.0
         imagePullPolicy: IfNotPresent
         name: vpp
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
         securityContext:
           privileged: true
         volumeMounts:

--- a/ovl/k8s-cni-calico/default/etc/kubernetes/calico/calico.yaml
+++ b/ovl/k8s-cni-calico/default/etc/kubernetes/calico/calico.yaml
@@ -29,6 +29,13 @@ metadata:
   name: calico-node
   namespace: kube-system
 ---
+# Source: calico/templates/calico-node.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+---
 # Source: calico/templates/calico-config.yaml
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -276,6 +283,130 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: bgpfilters.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPFilter
+    listKind: BGPFilterList
+    plural: bgpfilters
+    singular: bgpfilter
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPFilterSpec contains the IPv4 and IPv6 filter rules of
+              the BGP Filter.
+            properties:
+              exportV4:
+                description: The ordered set of IPv4 BGPFilter rules acting on exporting
+                  routes to a peer.
+                items:
+                  description: BGPFilterRuleV4 defines a BGP filter rule consisting
+                    a single IPv4 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+              exportV6:
+                description: The ordered set of IPv6 BGPFilter rules acting on exporting
+                  routes to a peer.
+                items:
+                  description: BGPFilterRuleV6 defines a BGP filter rule consisting
+                    a single IPv6 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+              importV4:
+                description: The ordered set of IPv4 BGPFilter rules acting on importing
+                  routes from a peer.
+                items:
+                  description: BGPFilterRuleV4 defines a BGP filter rule consisting
+                    a single IPv4 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+              importV6:
+                description: The ordered set of IPv6 BGPFilter rules acting on importing
+                  routes from a peer.
+                items:
+                  description: BGPFilterRuleV6 defines a BGP filter rule consisting
+                    a single IPv6 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: calico/templates/kdd-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: bgppeers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org
@@ -310,6 +441,11 @@ spec:
                 description: The AS Number of the peer.
                 format: int32
                 type: integer
+              filters:
+                description: The ordered set of BGPFilters applied on this BGP peer.
+                items:
+                  type: string
+                type: array
               keepOriginalNextHop:
                 description: Option to keep the original nexthop field when routes
                   are sent to a BGP Peer. Setting "true" configures the selected BGP
@@ -856,6 +992,13 @@ spec:
                   connections.  The only reason to disable it is for debugging purposes.  [Default:
                   true]'
                 type: boolean
+              bpfDSROptoutCIDRs:
+                description: BPFDSROptoutCIDRs is a list of CIDRs which are excluded
+                  from DSR. That is, clients in those CIDRs will accesses nodeports
+                  as if BPFExternalServiceMode was set to Tunnel.
+                items:
+                  type: string
+                type: array
               bpfDataIfacePattern:
                 description: BPFDataIfacePattern is a regular expression that controls
                   which interfaces Felix should attach BPF programs to in order to
@@ -879,7 +1022,7 @@ spec:
                 description: 'BPFEnforceRPF enforce strict RPF on all host interfaces
                   with BPF programs regardless of what is the per-interfaces or global
                   setting. Possible values are Disabled, Strict or Loose. [Default:
-                  Strict]'
+                  Loose]'
                 type: string
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
@@ -1144,7 +1287,7 @@ spec:
                 type: integer
               healthTimeoutOverrides:
                 description: HealthTimeoutOverrides allows the internal watchdog timeouts
-                  of individual subcomponents to be overriden.  This is useful for
+                  of individual subcomponents to be overridden.  This is useful for
                   working around "false positive" liveness timeouts that can occur
                   in particularly stressful workloads or if CPU is constrained.  For
                   a list of active subcomponents, see Felix's logs.
@@ -1203,6 +1346,12 @@ spec:
                   be used. The default is Auto.
                 type: string
               iptablesFilterAllowAction:
+                type: string
+              iptablesFilterDenyAction:
+                description: IptablesFilterDenyAction controls what happens to traffic
+                  that is denied by network policy. By default Calico blocks traffic
+                  with an iptables "DROP" action. If you want to use "REJECT" action
+                  instead you can configure it in here.
                 type: string
               iptablesLockFilePath:
                 description: 'IptablesLockFilePath is the location of the iptables
@@ -4214,7 +4363,7 @@ rules:
     resources:
       - serviceaccounts/token
     resourceNames:
-      - calico-node
+      - calico-cni-plugin
     verbs:
       - create
   # The CNI plugin needs to get pods, nodes, and namespaces.
@@ -4231,7 +4380,7 @@ rules:
     resources:
       - endpointslices
     verbs:
-      - watch 
+      - watch
       - list
   - apiGroups: [""]
     resources:
@@ -4285,6 +4434,7 @@ rules:
       - globalfelixconfigs
       - felixconfigurations
       - bgppeers
+      - bgpfilters
       - globalbgpconfigs
       - bgpconfigurations
       - ippools
@@ -4368,6 +4518,41 @@ rules:
     verbs:
       - get
 ---
+# Source: calico/templates/calico-node-rbac.yaml
+# CNI cluster role
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: calico-cni-plugin
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+      - clusterinformations
+      - ippools
+      - ipreservations
+      - ipamconfigs
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+---
 # Source: calico/templates/calico-kube-controllers-rbac.yaml
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4394,6 +4579,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: calico-node
+  namespace: kube-system
+---
+# Source: calico/templates/calico-node-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-cni-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-cni-plugin
+subjects:
+- kind: ServiceAccount
+  name: calico-cni-plugin
   namespace: kube-system
 ---
 # Source: calico/templates/calico-node.yaml
@@ -4442,7 +4641,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.25.1
+          image: docker.io/calico/cni:v3.26.4
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4470,7 +4669,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.25.1
+          image: docker.io/calico/cni:v3.26.4
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4513,7 +4712,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.25.1
+          image: docker.io/calico/node:v3.26.4
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4539,7 +4738,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.25.1
+          image: docker.io/calico/node:v3.26.4
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4768,7 +4967,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.25.1
+          image: docker.io/calico/kube-controllers:v3.26.4
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/ovl/k8s-cni-calico/default/etc/kubernetes/calico/calicoctl.yaml
+++ b/ovl/k8s-cni-calico/default/etc/kubernetes/calico/calicoctl.yaml
@@ -1,7 +1,7 @@
-# Calico Version v3.22.1
-# https://projectcalico.docs.tigera.io/releases#v3.22.1
+# Calico Version master
+# https://projectcalico.docs.tigera.io/releases#master
 # This manifest includes the following component versions:
-#   calico/ctl:v3.22.1
+#   calico/ctl:v3.26.4
 
 apiVersion: v1
 kind: ServiceAccount
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: calicoctl
   containers:
   - name: calicoctl
-    image: docker.io/calico/ctl:v3.22.1
+    image: calico/ctl:v3.26.4
     command:
       - /calicoctl
     args:

--- a/ovl/k8s-cni-calico/default/etc/kubernetes/calico/install-vpp.yaml
+++ b/ovl/k8s-cni-calico/default/etc/kubernetes/calico/install-vpp.yaml
@@ -1,5 +1,5 @@
 # This section includes base Calico installation configuration.
-# For more information, see: https://projectcalico.docs.tigera.io/master/reference/installation/api#operator.tigera.io/v1.Installation
+# For more information, see: https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.Installation
 apiVersion: operator.tigera.io/v1
 kind: Installation
 metadata:

--- a/ovl/k8s-cni-calico/default/etc/kubernetes/calico/tigera-operator.yaml
+++ b/ovl/k8s-cni-calico/default/etc/kubernetes/calico/tigera-operator.yaml
@@ -71,6 +71,12 @@ spec:
                       type: string
                   type: object
                 type: array
+              ignoredInterfaces:
+                description: IgnoredInterfaces indicates the network interfaces that
+                  needs to be excluded when reading device routes.
+                items:
+                  type: string
+                type: array
               listenPort:
                 description: ListenPort is the port where BGP protocol should listen.
                   Defaults to 179
@@ -187,6 +193,131 @@ status:
   storedVersions: []
 
 ---
+# Source: crds/calico/crd.projectcalico.org_bgpfilters.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: bgpfilters.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPFilter
+    listKind: BGPFilterList
+    plural: bgpfilters
+    singular: bgpfilter
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPFilterSpec contains the IPv4 and IPv6 filter rules of
+              the BGP Filter.
+            properties:
+              exportV4:
+                description: The ordered set of IPv4 BGPFilter rules acting on exporting
+                  routes to a peer.
+                items:
+                  description: BGPFilterRuleV4 defines a BGP filter rule consisting
+                    a single IPv4 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+              exportV6:
+                description: The ordered set of IPv6 BGPFilter rules acting on exporting
+                  routes to a peer.
+                items:
+                  description: BGPFilterRuleV6 defines a BGP filter rule consisting
+                    a single IPv6 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+              importV4:
+                description: The ordered set of IPv4 BGPFilter rules acting on importing
+                  routes from a peer.
+                items:
+                  description: BGPFilterRuleV4 defines a BGP filter rule consisting
+                    a single IPv4 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+              importV6:
+                description: The ordered set of IPv6 BGPFilter rules acting on importing
+                  routes from a peer.
+                items:
+                  description: BGPFilterRuleV6 defines a BGP filter rule consisting
+                    a single IPv6 CIDR block and a filter action for this CIDR.
+                  properties:
+                    action:
+                      type: string
+                    cidr:
+                      type: string
+                    matchOperator:
+                      type: string
+                  required:
+                  - action
+                  - cidr
+                  - matchOperator
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
 # Source: crds/calico/crd.projectcalico.org_bgppeers.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -225,6 +356,11 @@ spec:
                 description: The AS Number of the peer.
                 format: int32
                 type: integer
+              filters:
+                description: The ordered set of BGPFilters applied on this BGP peer.
+                items:
+                  type: string
+                type: array
               keepOriginalNextHop:
                 description: Option to keep the original nexthop field when routes
                   are sent to a BGP Peer. Setting "true" configures the selected BGP
@@ -290,12 +426,23 @@ spec:
                   remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
                   or the global default if that is not set.
                 type: string
+              reachableBy:
+                description: Add an exact, i.e. /32, static route toward peer IP in
+                  order to prevent route flapping. ReachableBy contains the address
+                  of the gateway which peer can be reached by.
+                type: string
               sourceAddress:
                 description: Specifies whether and how to configure a source address
                   for the peerings generated by this BGPPeer resource.  Default value
                   "UseNodeIP" means to configure the node IP as the source address.  "None"
                   means not to configure a source address.
                 type: string
+              ttlSecurity:
+                description: TTLSecurity enables the generalized TTL security mechanism
+                  (GTSM) which protects against spoofed packets by ignoring received
+                  packets with a smaller than expected TTL value. The provided value
+                  is the number of hops (edges) between the peers.
+                type: integer
             type: object
         type: object
     served: true
@@ -764,6 +911,13 @@ spec:
                   connections.  The only reason to disable it is for debugging purposes.  [Default:
                   true]'
                 type: boolean
+              bpfDSROptoutCIDRs:
+                description: BPFDSROptoutCIDRs is a list of CIDRs which are excluded
+                  from DSR. That is, clients in those CIDRs will accesses nodeports
+                  as if BPFExternalServiceMode was set to Tunnel.
+                items:
+                  type: string
+                type: array
               bpfDataIfacePattern:
                 description: BPFDataIfacePattern is a regular expression that controls
                   which interfaces Felix should attach BPF programs to in order to
@@ -784,9 +938,10 @@ spec:
                   [Default: false]'
                 type: boolean
               bpfEnforceRPF:
-                description: 'BPFEnforceRPF enforce strict RPF on all interfaces with
-                  BPF programs regardless of what is the per-interfaces or global
-                  setting. Possible values are Disabled or Strict. [Default: Strict]'
+                description: 'BPFEnforceRPF enforce strict RPF on all host interfaces
+                  with BPF programs regardless of what is the per-interfaces or global
+                  setting. Possible values are Disabled, Strict or Loose. [Default:
+                  Loose]'
                 type: string
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
@@ -825,6 +980,14 @@ spec:
                   minimum time between updates to the dataplane for Felix''s embedded
                   kube-proxy.  Lower values give reduced set-up latency.  Higher values
                   reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                type: string
+              bpfL3IfacePattern:
+                description: BPFL3IfacePattern is a regular expression that allows
+                  to list tunnel devices like wireguard or vxlan (i.e., L3 devices)
+                  in addition to BPFDataIfacePattern. That is, tunnel interfaces not
+                  created by Calico, that Calico workload traffic flows over as well
+                  as any interfaces that handle incoming traffic to nodeports and
+                  services from outside the cluster.
                 type: string
               bpfLogLevel:
                 description: 'BPFLogLevel controls the log level of the BPF programs
@@ -901,11 +1064,12 @@ spec:
                   to use.  Only used if UseInternalDataplaneDriver is set to false.
                 type: string
               dataplaneWatchdogTimeout:
-                description: 'DataplaneWatchdogTimeout is the readiness/liveness timeout
-                  used for Felix''s (internal) dataplane driver. Increase this value
+                description: "DataplaneWatchdogTimeout is the readiness/liveness timeout
+                  used for Felix's (internal) dataplane driver. Increase this value
                   if you experience spurious non-ready or non-live events when Felix
                   is under heavy load. Decrease the value to get felix to report non-live
-                  or non-ready more quickly. [Default: 90s]'
+                  or non-ready more quickly. [Default: 90s] \n Deprecated: replaced
+                  by the generic HealthTimeoutOverrides."
                 type: string
               debugDisableLogDropping:
                 type: boolean
@@ -1009,15 +1173,21 @@ spec:
                   type: object
                 type: array
               featureDetectOverride:
-                description: FeatureDetectOverride is used to override the feature
-                  detection. Values are specified in a comma separated list with no
-                  spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
-                  "true" or "false" will force the feature, empty or omitted values
-                  are auto-detected.
+                description: FeatureDetectOverride is used to override feature detection
+                  based on auto-detected platform capabilities.  Values are specified
+                  in a comma separated list with no spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".  "true"
+                  or "false" will force the feature, empty or omitted values are auto-detected.
+                type: string
+              featureGates:
+                description: FeatureGates is used to enable or disable tech-preview
+                  Calico features. Values are specified in a comma separated list
+                  with no spaces, example; "BPFConnectTimeLoadBalancingWorkaround=enabled,XyZ=false".
+                  This is used to enable features that are not fully production ready.
                 type: string
               floatingIPs:
                 description: FloatingIPs configures whether or not Felix will program
-                  floating IP addresses.
+                  non-OpenStack floating IP addresses.  (OpenStack-derived floating
+                  IPs are always programmed, regardless of this setting.)
                 enum:
                 - Enabled
                 - Disabled
@@ -1034,6 +1204,23 @@ spec:
                 type: string
               healthPort:
                 type: integer
+              healthTimeoutOverrides:
+                description: HealthTimeoutOverrides allows the internal watchdog timeouts
+                  of individual subcomponents to be overridden.  This is useful for
+                  working around "false positive" liveness timeouts that can occur
+                  in particularly stressful workloads or if CPU is constrained.  For
+                  a list of active subcomponents, see Felix's logs.
+                items:
+                  properties:
+                    name:
+                      type: string
+                    timeout:
+                      type: string
+                  required:
+                  - name
+                  - timeout
+                  type: object
+                type: array
               interfaceExclude:
                 description: 'InterfaceExclude is a comma-separated list of interfaces
                   that Felix should exclude when monitoring for host endpoints. The
@@ -1075,9 +1262,15 @@ spec:
                 type: string
               iptablesBackend:
                 description: IptablesBackend specifies which backend of iptables will
-                  be used. The default is legacy.
+                  be used. The default is Auto.
                 type: string
               iptablesFilterAllowAction:
+                type: string
+              iptablesFilterDenyAction:
+                description: IptablesFilterDenyAction controls what happens to traffic
+                  that is denied by network policy. By default Calico blocks traffic
+                  with an iptables "DROP" action. If you want to use "REJECT" action
+                  instead you can configure it in here.
                 type: string
               iptablesLockFilePath:
                 description: 'IptablesLockFilePath is the location of the iptables
@@ -4006,8 +4199,6 @@ status:
 
 ---
 # Source: crds/operator.tigera.io_apiservers_crd.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4475,8 +4666,8 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
                                                     feature is enabled.
                                                   properties:
                                                     matchExpressions:
@@ -4673,7 +4864,7 @@ spec:
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
                                                 matches all namespaces. This field
-                                                is alpha-level and is only honored
+                                                is beta-level and is only honored
                                                 when PodAffinityNamespaceSelector
                                                 feature is enabled.
                                               properties:
@@ -4869,8 +5060,8 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
                                                     feature is enabled.
                                                   properties:
                                                     matchExpressions:
@@ -5067,7 +5258,7 @@ spec:
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
                                                 matches all namespaces. This field
-                                                is alpha-level and is only honored
+                                                is beta-level and is only honored
                                                 when PodAffinityNamespaceSelector
                                                 feature is enabled.
                                               properties:
@@ -5367,8 +5558,6 @@ status:
 
 ---
 # Source: crds/operator.tigera.io_imagesets_crd.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5389,7 +5578,7 @@ spec:
       openAPIV3Schema:
         description: ImageSet is used to specify image digests for the images that
           the operator deploys. The name of the ImageSet is expected to be in the
-          format `<variang>-<release>`. The `variant` used is `enterprise` if the
+          format `<variant>-<release>`. The `variant` used is `enterprise` if the
           InstallationSpec Variant is `TigeraSecureEnterprise` otherwise it is `calico`.
           The `release` must match the version of the variant that the operator is
           built to deploy, this version can be obtained by passing the `--version`
@@ -5447,13 +5636,11 @@ status:
 
 ---
 # Source: crds/operator.tigera.io_installations_crd.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   name: installations.operator.tigera.io
 spec:
   group: operator.tigera.io
@@ -5690,6 +5877,7 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             weight:
                                               description: Weight associated with
                                                 matching the corresponding nodeSelectorTerm,
@@ -5809,10 +5997,12 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             type: array
                                         required:
                                         - nodeSelectorTerms
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                   podAffinity:
                                     description: Describes pod affinity scheduling
@@ -5910,6 +6100,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -5921,9 +6112,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -5985,6 +6173,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -5994,7 +6183,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -6109,6 +6298,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -6118,10 +6308,7 @@ spec:
                                                 field. null selector and null or empty
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
-                                                matches all namespaces. This field
-                                                is alpha-level and is only honored
-                                                when PodAffinityNamespaceSelector
-                                                feature is enabled.
+                                                matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -6179,6 +6366,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -6187,7 +6375,7 @@ spec:
                                                 in this field and the ones selected
                                                 by namespaceSelector. null or empty
                                                 namespaces list and null namespaceSelector
-                                                means "this pod's namespace"
+                                                means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -6304,6 +6492,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -6315,9 +6504,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -6379,6 +6565,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -6388,7 +6575,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -6503,6 +6690,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -6512,10 +6700,7 @@ spec:
                                                 field. null selector and null or empty
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
-                                                matches all namespaces. This field
-                                                is alpha-level and is only honored
-                                                when PodAffinityNamespaceSelector
-                                                feature is enabled.
+                                                matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -6573,6 +6758,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -6581,7 +6767,7 @@ spec:
                                                 in this field and the ones selected
                                                 by namespaceSelector. null or empty
                                                 namespaces list and null namespaceSelector
-                                                means "this pod's namespace"
+                                                means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -7109,6 +7295,7 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             weight:
                                               description: Weight associated with
                                                 matching the corresponding nodeSelectorTerm,
@@ -7228,10 +7415,12 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             type: array
                                         required:
                                         - nodeSelectorTerms
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                   podAffinity:
                                     description: Describes pod affinity scheduling
@@ -7329,6 +7518,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -7340,9 +7530,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -7404,6 +7591,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -7413,7 +7601,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -7528,6 +7716,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -7537,10 +7726,7 @@ spec:
                                                 field. null selector and null or empty
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
-                                                matches all namespaces. This field
-                                                is alpha-level and is only honored
-                                                when PodAffinityNamespaceSelector
-                                                feature is enabled.
+                                                matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -7598,6 +7784,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -7606,7 +7793,7 @@ spec:
                                                 in this field and the ones selected
                                                 by namespaceSelector. null or empty
                                                 namespaces list and null namespaceSelector
-                                                means "this pod's namespace"
+                                                means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -7723,6 +7910,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -7734,9 +7922,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -7798,6 +7983,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -7807,7 +7993,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -7922,6 +8108,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -7931,10 +8118,7 @@ spec:
                                                 field. null selector and null or empty
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
-                                                matches all namespaces. This field
-                                                is alpha-level and is only honored
-                                                when PodAffinityNamespaceSelector
-                                                feature is enabled.
+                                                matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -7992,6 +8176,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -8000,7 +8185,7 @@ spec:
                                                 in this field and the ones selected
                                                 by namespaceSelector. null or empty
                                                 namespaces list and null namespaceSelector
-                                                means "this pod's namespace"
+                                                means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -8411,6 +8596,7 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             weight:
                                               description: Weight associated with
                                                 matching the corresponding nodeSelectorTerm,
@@ -8530,10 +8716,12 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             type: array
                                         required:
                                         - nodeSelectorTerms
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                   podAffinity:
                                     description: Describes pod affinity scheduling
@@ -8631,6 +8819,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -8642,9 +8831,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -8706,6 +8892,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -8715,7 +8902,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -8830,6 +9017,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -8839,10 +9027,7 @@ spec:
                                                 field. null selector and null or empty
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
-                                                matches all namespaces. This field
-                                                is alpha-level and is only honored
-                                                when PodAffinityNamespaceSelector
-                                                feature is enabled.
+                                                matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -8900,6 +9085,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -8908,7 +9094,7 @@ spec:
                                                 in this field and the ones selected
                                                 by namespaceSelector. null or empty
                                                 namespaces list and null namespaceSelector
-                                                means "this pod's namespace"
+                                                means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -9025,6 +9211,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -9036,9 +9223,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -9100,6 +9284,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -9109,7 +9294,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -9224,6 +9409,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -9233,10 +9419,7 @@ spec:
                                                 field. null selector and null or empty
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
-                                                matches all namespaces. This field
-                                                is alpha-level and is only honored
-                                                when PodAffinityNamespaceSelector
-                                                feature is enabled.
+                                                matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -9294,6 +9477,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -9302,7 +9486,7 @@ spec:
                                                 in this field and the ones selected
                                                 by namespaceSelector. null or empty
                                                 namespaces list and null namespaceSelector
-                                                means "this pod's namespace"
+                                                means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -9651,6 +9835,1243 @@ spec:
                       type: string
                   type: object
                 type: array
+              csiNodeDriverDaemonSet:
+                description: CSINodeDriverDaemonSet configures the csi-node-driver
+                  DaemonSet.
+                properties:
+                  metadata:
+                    description: Metadata is a subset of a Kubernetes object's metadata
+                      that is added to the DaemonSet.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of arbitrary non-identifying
+                          metadata. Each of these key/value pairs are added to the
+                          object's annotations provided the key does not already exist
+                          in the object's annotations.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values that
+                          may match replicaset and service selectors. Each of these
+                          key/value pairs are added to the object's labels provided
+                          the key does not already exist in the object's labels.
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the csi-node-driver
+                      DaemonSet.
+                    properties:
+                      minReadySeconds:
+                        description: MinReadySeconds is the minimum number of seconds
+                          for which a newly created DaemonSet pod should be ready
+                          without any of its container crashing, for it to be considered
+                          available. If specified, this overrides any minReadySeconds
+                          value that may be set on the csi-node-driver DaemonSet.
+                          If omitted, the csi-node-driver DaemonSet will use its default
+                          value for minReadySeconds.
+                        format: int32
+                        maximum: 2147483647
+                        minimum: 0
+                        type: integer
+                      template:
+                        description: Template describes the csi-node-driver DaemonSet
+                          pod that will be created.
+                        properties:
+                          metadata:
+                            description: Metadata is a subset of a Kubernetes object's
+                              metadata that is added to the pod's metadata.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a map of arbitrary non-identifying
+                                  metadata. Each of these key/value pairs are added
+                                  to the object's annotations provided the key does
+                                  not already exist in the object's annotations.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a map of string keys and values
+                                  that may match replicaset and service selectors.
+                                  Each of these key/value pairs are added to the object's
+                                  labels provided the key does not already exist in
+                                  the object's labels.
+                                type: object
+                            type: object
+                          spec:
+                            description: Spec is the csi-node-driver DaemonSet's PodSpec.
+                            properties:
+                              affinity:
+                                description: 'Affinity is a group of affinity scheduling
+                                  rules for the csi-node-driver pods. If specified,
+                                  this overrides any affinity that may be set on the
+                                  csi-node-driver DaemonSet. If omitted, the csi-node-driver
+                                  DaemonSet will use its default value for affinity.
+                                  WARNING: Please note that this field will override
+                                  the default csi-node-driver DaemonSet affinity.'
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the
+                                          most preferred.
+                                        items:
+                                          description: An empty preferred scheduling
+                                            term matches all objects with implicit
+                                            weight 0 (i.e. it's a no-op). A null preferred
+                                            scheduling term matches no objects (i.e.
+                                            is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to an update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: A null or empty node selector
+                                                term matches no objects. The requirements
+                                                of them are ANDed. The TopologySelectorTerm
+                                                type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod
+                                          label update), the system may or may not
+                                          try to eventually evict the pod from its
+                                          node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          anti-affinity expressions specified by this
+                                          field, but it may choose a node that violates
+                                          one or more of the expressions. The node
+                                          that is most preferred is the one with the
+                                          greatest sum of weights, i.e. for each node
+                                          that meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          anti-affinity expressions, etc.), compute
+                                          a sum by iterating through the elements
+                                          of this field and adding "weight" to the
+                                          sum if the node has pods which matches the
+                                          corresponding podAffinityTerm; the node(s)
+                                          with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the anti-affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the anti-affinity requirements
+                                          specified by this field cease to be met
+                                          at some point during pod execution (e.g.
+                                          due to a pod label update), the system may
+                                          or may not try to eventually evict the pod
+                                          from its node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              containers:
+                                description: Containers is a list of csi-node-driver
+                                  containers. If specified, this overrides the specified
+                                  csi-node-driver DaemonSet containers. If omitted,
+                                  the csi-node-driver DaemonSet will use its default
+                                  values for its containers.
+                                items:
+                                  description: CSINodeDriverDaemonSetContainer is
+                                    a csi-node-driver DaemonSet container.
+                                  properties:
+                                    name:
+                                      description: Name is an enum which identifies
+                                        the csi-node-driver DaemonSet container by
+                                        name.
+                                      enum:
+                                      - csi-node-driver
+                                      type: string
+                                    resources:
+                                      description: Resources allows customization
+                                        of limits and requests for compute resources
+                                        such as cpu and memory. If specified, this
+                                        overrides the named csi-node-driver DaemonSet
+                                        container's resources. If omitted, the csi-node-driver
+                                        DaemonSet will use its default value for this
+                                        container's resources.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is the csi-node-driver
+                                  pod''s scheduling constraints. If specified, each
+                                  of the key/value pairs are added to the csi-node-driver
+                                  DaemonSet nodeSelector provided the key does not
+                                  already exist in the object''s nodeSelector. If
+                                  omitted, the csi-node-driver DaemonSet will use
+                                  its default value for nodeSelector. WARNING: Please
+                                  note that this field will modify the default csi-node-driver
+                                  DaemonSet nodeSelector.'
+                                type: object
+                              tolerations:
+                                description: 'Tolerations is the csi-node-driver pod''s
+                                  tolerations. If specified, this overrides any tolerations
+                                  that may be set on the csi-node-driver DaemonSet.
+                                  If omitted, the csi-node-driver DaemonSet will use
+                                  its default value for tolerations. WARNING: Please
+                                  note that this field will override the default csi-node-driver
+                                  DaemonSet tolerations.'
+                                items:
+                                  description: The pod this Toleration is attached
+                                    to tolerates any taint that matches the triple
+                                    <key,value,effect> using the matching operator
+                                    <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect
+                                        to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule,
+                                        PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration
+                                        applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists;
+                                        this combination means to match all values
+                                        and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship
+                                        to the value. Valid operators are Exists and
+                                        Equal. Defaults to Equal. Exists is equivalent
+                                        to wildcard for value, so that a pod can tolerate
+                                        all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the
+                                        period of time the toleration (which must
+                                        be of effect NoExecute, otherwise this field
+                                        is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint
+                                        forever (do not evict). Zero and negative
+                                        values will be treated as 0 (evict immediately)
+                                        by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration
+                                        matches to. If the operator is Exists, the
+                                        value should be empty, otherwise just a regular
+                                        string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
               fipsMode:
                 description: 'FIPSMode uses images and features only that are using
                   FIPS 140-2 validated cryptographic modules and standards. Default:
@@ -9671,7 +11092,7 @@ spec:
                   the image path for each image. If not specified or empty, the default
                   for each image will be used. A special case value, UseDefault, is
                   supported to explicitly specify the default image path will be used
-                  for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  for each image. \n Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                   \n This option allows configuring the `<imagePath>` portion of the
                   above format."
                 type: string
@@ -9681,7 +11102,7 @@ spec:
                   a prefix on each image. If not specified or empty, no prefix will
                   be used. A special case value, UseDefault, is supported to explicitly
                   specify the default image prefix will be used for each image. \n
-                  Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                   \n This option allows configuring the `<imagePrefix>` portion of
                   the above format."
                 type: string
@@ -9698,6 +11119,7 @@ spec:
                         TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
+                  x-kubernetes-map-type: atomic
                 type: array
               kubeletVolumePluginPath:
                 description: 'KubeletVolumePluginPath optionally specifies enablement
@@ -9721,6 +11143,37 @@ spec:
                 - DockerEnterprise
                 - RKE2
                 type: string
+              logging:
+                description: Logging Configuration for Components
+                properties:
+                  cni:
+                    description: Customized logging specification for calico-cni plugin
+                    properties:
+                      logFileMaxAgeDays:
+                        description: 'Default: 30 (days)'
+                        format: int32
+                        type: integer
+                      logFileMaxCount:
+                        description: 'Default: 10'
+                        format: int32
+                        type: integer
+                      logFileMaxSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'Default: 100Mi'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      logSeverity:
+                        description: 'Default: Info'
+                        enum:
+                        - Error
+                        - Warning
+                        - Debug
+                        - Info
+                        type: string
+                    type: object
+                type: object
               nodeMetricsPort:
                 description: NodeMetricsPort specifies which port calico/node serves
                   prometheus metrics on. By default, metrics are not enabled. If specified,
@@ -9763,9 +11216,7 @@ spec:
                           the possibility that the resources consumed by the daemonset
                           on any given node can double if the readiness check fails,
                           and so resource intensive daemonsets should take into account
-                          that they may cause evictions during disruption. This is
-                          an alpha field and requires enabling DaemonSetUpdateSurge
-                          feature gate.'
+                          that they may cause evictions during disruption.'
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
@@ -9775,18 +11226,17 @@ spec:
                           be unavailable during the update. Value can be an absolute
                           number (ex: 5) or a percentage of total number of DaemonSet
                           pods at the start of the update (ex: 10%). Absolute number
-                          is calculated from percentage by rounding down to a minimum
-                          of one. This cannot be 0 if MaxSurge is 0 Default value
-                          is 1. Example: when this is set to 30%, at most 30% of the
-                          total number of nodes that should be running the daemon
-                          pod (i.e. status.desiredNumberScheduled) can have their
-                          pods stopped for an update at any given time. The update
-                          starts by stopping at most 30% of those DaemonSet pods and
-                          then brings up new DaemonSet pods in their place. Once the
-                          new pods are available, it then proceeds onto other DaemonSet
-                          pods, thus ensuring that at least 70% of original number
-                          of DaemonSet pods are available at all times during the
-                          update.'
+                          is calculated from percentage by rounding up. This cannot
+                          be 0 if MaxSurge is 0 Default value is 1. Example: when
+                          this is set to 30%, at most 30% of the total number of nodes
+                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their pods stopped for an update at any given time.
+                          The update starts by stopping at most 30% of those DaemonSet
+                          pods and then brings up new DaemonSet pods in their place.
+                          Once the new pods are available, it then proceeds onto other
+                          DaemonSet pods, thus ensuring that at least 70% of original
+                          number of DaemonSet pods are available at all times during
+                          the update.'
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
@@ -9804,7 +11254,7 @@ spec:
                   slash character (`/`) and all images will be pulled from this registry.
                   If not specified then the default registries will be used. A special
                   case value, UseDefault, is supported to explicitly specify the default
-                  registries will be used. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  registries will be used. \n Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                   \n This option allows configuring the `<registry>` portion of the
                   above format."
                 type: string
@@ -9905,6 +11355,7 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             weight:
                               description: Weight associated with matching the corresponding
                                 nodeSelectorTerm, in the range 1-100.
@@ -10015,10 +11466,12 @@ spec:
                                     type: object
                                   type: array
                               type: object
+                              x-kubernetes-map-type: atomic
                             type: array
                         required:
                         - nodeSelectorTerms
                         type: object
+                        x-kubernetes-map-type: atomic
                     type: object
                 type: object
               typhaDeployment:
@@ -10061,6 +11514,53 @@ spec:
                         maximum: 2147483647
                         minimum: 0
                         type: integer
+                      strategy:
+                        description: The deployment strategy to use to replace existing
+                          pods with new ones.
+                        properties:
+                          rollingUpdate:
+                            description: Rolling update config params. Present only
+                              if DeploymentStrategyType = RollingUpdate. to be.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can
+                                  be scheduled above the desired number of pods. Value
+                                  can be an absolute number (ex: 5) or a percentage
+                                  of desired pods (ex: 10%). This can not be 0 if
+                                  MaxUnavailable is 0. Absolute number is calculated
+                                  from percentage by rounding up. Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet
+                                  can be scaled up immediately when the rolling update
+                                  starts, such that the total number of old and new
+                                  pods do not exceed 130% of desired pods. Once old
+                                  pods have been killed, new ReplicaSet can be scaled
+                                  up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of
+                                  desired pods.'
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can
+                                  be unavailable during the update. Value can be an
+                                  absolute number (ex: 5) or a percentage of desired
+                                  pods (ex: 10%). Absolute number is calculated from
+                                  percentage by rounding down. This can not be 0 if
+                                  MaxSurge is 0. Defaults to 25%. Example: when this
+                                  is set to 30%, the old ReplicaSet can be scaled
+                                  down to 70% of desired pods immediately when the
+                                  rolling update starts. Once new pods are ready,
+                                  old ReplicaSet can be scaled down further, followed
+                                  by scaling up the new ReplicaSet, ensuring that
+                                  the total number of pods available at all times
+                                  during the update is at least 70% of desired pods.'
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       template:
                         description: Template describes the typha Deployment pod that
                           will be created.
@@ -10221,6 +11721,7 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             weight:
                                               description: Weight associated with
                                                 matching the corresponding nodeSelectorTerm,
@@ -10340,10 +11841,12 @@ spec:
                                                     type: object
                                                   type: array
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             type: array
                                         required:
                                         - nodeSelectorTerms
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                   podAffinity:
                                     description: Describes pod affinity scheduling
@@ -10441,6 +11944,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -10452,9 +11956,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -10516,6 +12017,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -10525,7 +12027,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -10640,6 +12142,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -10649,10 +12152,7 @@ spec:
                                                 field. null selector and null or empty
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
-                                                matches all namespaces. This field
-                                                is alpha-level and is only honored
-                                                when PodAffinityNamespaceSelector
-                                                feature is enabled.
+                                                matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -10710,6 +12210,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -10718,7 +12219,7 @@ spec:
                                                 in this field and the ones selected
                                                 by namespaceSelector. null or empty
                                                 namespaces list and null namespaceSelector
-                                                means "this pod's namespace"
+                                                means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -10835,6 +12336,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -10846,9 +12348,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -10910,6 +12409,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -10919,7 +12419,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -11034,6 +12534,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaceSelector:
                                               description: A label query over the
                                                 set of namespaces that the term applies
@@ -11043,10 +12544,7 @@ spec:
                                                 field. null selector and null or empty
                                                 namespaces list means "this pod's
                                                 namespace". An empty selector ({})
-                                                matches all namespaces. This field
-                                                is alpha-level and is only honored
-                                                when PodAffinityNamespaceSelector
-                                                feature is enabled.
+                                                matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -11104,6 +12602,7 @@ spec:
                                                     are ANDed.
                                                   type: object
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             namespaces:
                                               description: namespaces specifies a
                                                 static list of namespace names that
@@ -11112,7 +12611,7 @@ spec:
                                                 in this field and the ones selected
                                                 by namespaceSelector. null or empty
                                                 namespaces list and null namespaceSelector
-                                                means "this pod's namespace"
+                                                means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
@@ -11259,6 +12758,21 @@ spec:
                                   WARNING: Please note that this field will modify
                                   the default calico-typha Deployment nodeSelector.'
                                 type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully. May be decreased
+                                  in delete request. Value must be non-negative integer.
+                                  The value zero indicates stop immediately via the
+                                  kill signal (no opportunity to shut down). If this
+                                  value is nil, the default grace period will be used
+                                  instead. The grace period is the duration in seconds
+                                  after the processes running in the pod are sent
+                                  a termination signal and the time when the processes
+                                  are forcibly halted with a kill signal. Set this
+                                  value longer than the expected cleanup time for
+                                  your process. Defaults to 30 seconds.
+                                format: int64
+                                type: integer
                               tolerations:
                                 description: 'Tolerations is the typha pod''s tolerations.
                                   If specified, this overrides any tolerations that
@@ -11312,6 +12826,216 @@ spec:
                                       type: string
                                   type: object
                                 type: array
+                              topologySpreadConstraints:
+                                description: TopologySpreadConstraints describes how
+                                  a group of pods ought to spread across topology
+                                  domains. Scheduler will schedule pods in a way which
+                                  abides by the constraints. All topologySpreadConstraints
+                                  are ANDed.
+                                items:
+                                  description: TopologySpreadConstraint specifies
+                                    how to spread matching pods among the given topology.
+                                  properties:
+                                    labelSelector:
+                                      description: LabelSelector is used to find matching
+                                        pods. Pods that match this label selector
+                                        are counted to determine the number of pods
+                                        in their corresponding topology domain.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select the pods over which spreading
+                                        will be calculated. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are ANDed with labelSelector
+                                        to select the group of existing pods over
+                                        which spreading will be calculated for the
+                                        incoming pod. Keys that don't exist in the
+                                        incoming pod labels will be ignored. A null
+                                        or empty list means only match against labelSelector.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    maxSkew:
+                                      description: 'MaxSkew describes the degree to
+                                        which pods may be unevenly distributed. When
+                                        `whenUnsatisfiable=DoNotSchedule`, it is the
+                                        maximum permitted difference between the number
+                                        of matching pods in the target topology and
+                                        the global minimum. The global minimum is
+                                        the minimum number of matching pods in an
+                                        eligible domain or zero if the number of eligible
+                                        domains is less than MinDomains. For example,
+                                        in a 3-zone cluster, MaxSkew is set to 1,
+                                        and pods with the same labelSelector spread
+                                        as 2/2/1: In this case, the global minimum
+                                        is 1. | zone1 | zone2 | zone3 | |  P P  |  P
+                                        P  |   P   | - if MaxSkew is 1, incoming pod
+                                        can only be scheduled to zone3 to become 2/2/2;
+                                        scheduling it onto zone1(zone2) would make
+                                        the ActualSkew(3-1) on zone1(zone2) violate
+                                        MaxSkew(1). - if MaxSkew is 2, incoming pod
+                                        can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                        it is used to give higher precedence to topologies
+                                        that satisfy it. It''s a required field. Default
+                                        value is 1 and 0 is not allowed.'
+                                      format: int32
+                                      type: integer
+                                    minDomains:
+                                      description: "MinDomains indicates a minimum
+                                        number of eligible domains. When the number
+                                        of eligible domains with matching topology
+                                        keys is less than minDomains, Pod Topology
+                                        Spread treats \"global minimum\" as 0, and
+                                        then the calculation of Skew is performed.
+                                        And when the number of eligible domains with
+                                        matching topology keys equals or greater than
+                                        minDomains, this value has no effect on scheduling.
+                                        As a result, when the number of eligible domains
+                                        is less than minDomains, scheduler won't schedule
+                                        more than maxSkew Pods to those domains. If
+                                        value is nil, the constraint behaves as if
+                                        MinDomains is equal to 1. Valid values are
+                                        integers greater than 0. When value is not
+                                        nil, WhenUnsatisfiable must be DoNotSchedule.
+                                        \n For example, in a 3-zone cluster, MaxSkew
+                                        is set to 2, MinDomains is set to 5 and pods
+                                        with the same labelSelector spread as 2/2/2:
+                                        | zone1 | zone2 | zone3 | |  P P  |  P P  |
+                                        \ P P  | The number of domains is less than
+                                        5(MinDomains), so \"global minimum\" is treated
+                                        as 0. In this situation, new pod with the
+                                        same labelSelector cannot be scheduled, because
+                                        computed skew will be 3(3 - 0) if new Pod
+                                        is scheduled to any of the three zones, it
+                                        will violate MaxSkew. \n This is a beta field
+                                        and requires the MinDomainsInPodTopologySpread
+                                        feature gate to be enabled (enabled by default)."
+                                      format: int32
+                                      type: integer
+                                    nodeAffinityPolicy:
+                                      description: "NodeAffinityPolicy indicates how
+                                        we will treat Pod's nodeAffinity/nodeSelector
+                                        when calculating pod topology spread skew.
+                                        Options are: - Honor: only nodes matching
+                                        nodeAffinity/nodeSelector are included in
+                                        the calculations. - Ignore: nodeAffinity/nodeSelector
+                                        are ignored. All nodes are included in the
+                                        calculations. \n If this value is nil, the
+                                        behavior is equivalent to the Honor policy.
+                                        This is a alpha-level feature enabled by the
+                                        NodeInclusionPolicyInPodTopologySpread feature
+                                        flag."
+                                      type: string
+                                    nodeTaintsPolicy:
+                                      description: "NodeTaintsPolicy indicates how
+                                        we will treat node taints when calculating
+                                        pod topology spread skew. Options are: - Honor:
+                                        nodes without taints, along with tainted nodes
+                                        for which the incoming pod has a toleration,
+                                        are included. - Ignore: node taints are ignored.
+                                        All nodes are included. \n If this value is
+                                        nil, the behavior is equivalent to the Ignore
+                                        policy. This is a alpha-level feature enabled
+                                        by the NodeInclusionPolicyInPodTopologySpread
+                                        feature flag."
+                                      type: string
+                                    topologyKey:
+                                      description: TopologyKey is the key of node
+                                        labels. Nodes that have a label with this
+                                        key and identical values are considered to
+                                        be in the same topology. We consider each
+                                        <key, value> as a "bucket", and try to put
+                                        balanced number of pods into each bucket.
+                                        We define a domain as a particular instance
+                                        of a topology. Also, we define an eligible
+                                        domain as a domain whose nodes meet the requirements
+                                        of nodeAffinityPolicy and nodeTaintsPolicy.
+                                        e.g. If TopologyKey is "kubernetes.io/hostname",
+                                        each Node is a domain of that topology. And,
+                                        if TopologyKey is "topology.kubernetes.io/zone",
+                                        each zone is a domain of that topology. It's
+                                        a required field.
+                                      type: string
+                                    whenUnsatisfiable:
+                                      description: 'WhenUnsatisfiable indicates how
+                                        to deal with a pod if it doesn''t satisfy
+                                        the spread constraint. - DoNotSchedule (default)
+                                        tells the scheduler not to schedule it. -
+                                        ScheduleAnyway tells the scheduler to schedule
+                                        the pod in any location, but giving higher
+                                        precedence to topologies that would help reduce
+                                        the skew. A constraint is considered "Unsatisfiable"
+                                        for an incoming pod if and only if every possible
+                                        node assignment for that pod would violate
+                                        "MaxSkew" on some topology. For example, in
+                                        a 3-zone cluster, MaxSkew is set to 1, and
+                                        pods with the same labelSelector spread as
+                                        3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                                        If WhenUnsatisfiable is set to DoNotSchedule,
+                                        incoming pod can only be scheduled to zone2(zone3)
+                                        to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                        on zone2(zone3) satisfies MaxSkew(1). In other
+                                        words, the cluster can still be imbalanced,
+                                        but scheduler won''t make it *more* imbalanced.
+                                        It''s a required field.'
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
                             type: object
                         type: object
                     type: object
@@ -11333,6 +13057,11 @@ spec:
             description: Most recently observed state for the Calico or Calico Enterprise
               installation.
             properties:
+              calicoVersion:
+                description: CalicoVersion shows the current running version of calico.
+                  CalicoVersion along with Variant is needed to know the exact version
+                  deployed.
+                type: string
               computed:
                 description: Computed is the final installation including overlaid
                   resources.
@@ -11554,6 +13283,7 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 weight:
                                                   description: Weight associated with
                                                     matching the corresponding nodeSelectorTerm,
@@ -11685,10 +13415,12 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 type: array
                                             required:
                                             - nodeSelectorTerms
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         type: object
                                       podAffinity:
                                         description: Describes pod affinity scheduling
@@ -11794,6 +13526,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -11806,10 +13539,7 @@ spec:
                                                         namespaces list means "this
                                                         pod's namespace". An empty
                                                         selector ({}) matches all
-                                                        namespaces. This field is
-                                                        alpha-level and is only honored
-                                                        when PodAffinityNamespaceSelector
-                                                        feature is enabled.
+                                                        namespaces.
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
@@ -11877,6 +13607,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -11887,7 +13618,7 @@ spec:
                                                         ones selected by namespaceSelector.
                                                         null or empty namespaces list
                                                         and null namespaceSelector
-                                                        means "this pod's namespace"
+                                                        means "this pod's namespace".
                                                       items:
                                                         type: string
                                                       type: array
@@ -12011,6 +13742,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -12022,9 +13754,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -12086,6 +13815,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -12095,7 +13825,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -12221,6 +13951,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -12233,10 +13964,7 @@ spec:
                                                         namespaces list means "this
                                                         pod's namespace". An empty
                                                         selector ({}) matches all
-                                                        namespaces. This field is
-                                                        alpha-level and is only honored
-                                                        when PodAffinityNamespaceSelector
-                                                        feature is enabled.
+                                                        namespaces.
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
@@ -12304,6 +14032,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -12314,7 +14043,7 @@ spec:
                                                         ones selected by namespaceSelector.
                                                         null or empty namespaces list
                                                         and null namespaceSelector
-                                                        means "this pod's namespace"
+                                                        means "this pod's namespace".
                                                       items:
                                                         type: string
                                                       type: array
@@ -12438,6 +14167,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -12449,9 +14179,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -12513,6 +14240,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -12522,7 +14250,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -13078,6 +14806,7 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 weight:
                                                   description: Weight associated with
                                                     matching the corresponding nodeSelectorTerm,
@@ -13209,10 +14938,12 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 type: array
                                             required:
                                             - nodeSelectorTerms
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         type: object
                                       podAffinity:
                                         description: Describes pod affinity scheduling
@@ -13318,6 +15049,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -13330,10 +15062,7 @@ spec:
                                                         namespaces list means "this
                                                         pod's namespace". An empty
                                                         selector ({}) matches all
-                                                        namespaces. This field is
-                                                        alpha-level and is only honored
-                                                        when PodAffinityNamespaceSelector
-                                                        feature is enabled.
+                                                        namespaces.
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
@@ -13401,6 +15130,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -13411,7 +15141,7 @@ spec:
                                                         ones selected by namespaceSelector.
                                                         null or empty namespaces list
                                                         and null namespaceSelector
-                                                        means "this pod's namespace"
+                                                        means "this pod's namespace".
                                                       items:
                                                         type: string
                                                       type: array
@@ -13535,6 +15265,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -13546,9 +15277,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -13610,6 +15338,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -13619,7 +15348,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -13745,6 +15474,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -13757,10 +15487,7 @@ spec:
                                                         namespaces list means "this
                                                         pod's namespace". An empty
                                                         selector ({}) matches all
-                                                        namespaces. This field is
-                                                        alpha-level and is only honored
-                                                        when PodAffinityNamespaceSelector
-                                                        feature is enabled.
+                                                        namespaces.
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
@@ -13828,6 +15555,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -13838,7 +15566,7 @@ spec:
                                                         ones selected by namespaceSelector.
                                                         null or empty namespaces list
                                                         and null namespaceSelector
-                                                        means "this pod's namespace"
+                                                        means "this pod's namespace".
                                                       items:
                                                         type: string
                                                       type: array
@@ -13962,6 +15690,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -13973,9 +15702,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -14037,6 +15763,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -14046,7 +15773,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -14482,6 +16209,7 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 weight:
                                                   description: Weight associated with
                                                     matching the corresponding nodeSelectorTerm,
@@ -14613,10 +16341,12 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 type: array
                                             required:
                                             - nodeSelectorTerms
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         type: object
                                       podAffinity:
                                         description: Describes pod affinity scheduling
@@ -14722,6 +16452,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -14734,10 +16465,7 @@ spec:
                                                         namespaces list means "this
                                                         pod's namespace". An empty
                                                         selector ({}) matches all
-                                                        namespaces. This field is
-                                                        alpha-level and is only honored
-                                                        when PodAffinityNamespaceSelector
-                                                        feature is enabled.
+                                                        namespaces.
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
@@ -14805,6 +16533,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -14815,7 +16544,7 @@ spec:
                                                         ones selected by namespaceSelector.
                                                         null or empty namespaces list
                                                         and null namespaceSelector
-                                                        means "this pod's namespace"
+                                                        means "this pod's namespace".
                                                       items:
                                                         type: string
                                                       type: array
@@ -14939,6 +16668,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -14950,9 +16680,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -15014,6 +16741,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -15023,7 +16751,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -15149,6 +16877,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -15161,10 +16890,7 @@ spec:
                                                         namespaces list means "this
                                                         pod's namespace". An empty
                                                         selector ({}) matches all
-                                                        namespaces. This field is
-                                                        alpha-level and is only honored
-                                                        when PodAffinityNamespaceSelector
-                                                        feature is enabled.
+                                                        namespaces.
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
@@ -15232,6 +16958,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -15242,7 +16969,7 @@ spec:
                                                         ones selected by namespaceSelector.
                                                         null or empty namespaces list
                                                         and null namespaceSelector
-                                                        means "this pod's namespace"
+                                                        means "this pod's namespace".
                                                       items:
                                                         type: string
                                                       type: array
@@ -15366,6 +17093,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -15377,9 +17105,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -15441,6 +17166,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -15450,7 +17176,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -15811,6 +17537,1341 @@ spec:
                           type: string
                       type: object
                     type: array
+                  csiNodeDriverDaemonSet:
+                    description: CSINodeDriverDaemonSet configures the csi-node-driver
+                      DaemonSet.
+                    properties:
+                      metadata:
+                        description: Metadata is a subset of a Kubernetes object's
+                          metadata that is added to the DaemonSet.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a map of arbitrary non-identifying
+                              metadata. Each of these key/value pairs are added to
+                              the object's annotations provided the key does not already
+                              exist in the object's annotations.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a map of string keys and values
+                              that may match replicaset and service selectors. Each
+                              of these key/value pairs are added to the object's labels
+                              provided the key does not already exist in the object's
+                              labels.
+                            type: object
+                        type: object
+                      spec:
+                        description: Spec is the specification of the csi-node-driver
+                          DaemonSet.
+                        properties:
+                          minReadySeconds:
+                            description: MinReadySeconds is the minimum number of
+                              seconds for which a newly created DaemonSet pod should
+                              be ready without any of its container crashing, for
+                              it to be considered available. If specified, this overrides
+                              any minReadySeconds value that may be set on the csi-node-driver
+                              DaemonSet. If omitted, the csi-node-driver DaemonSet
+                              will use its default value for minReadySeconds.
+                            format: int32
+                            maximum: 2147483647
+                            minimum: 0
+                            type: integer
+                          template:
+                            description: Template describes the csi-node-driver DaemonSet
+                              pod that will be created.
+                            properties:
+                              metadata:
+                                description: Metadata is a subset of a Kubernetes
+                                  object's metadata that is added to the pod's metadata.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a map of arbitrary
+                                      non-identifying metadata. Each of these key/value
+                                      pairs are added to the object's annotations
+                                      provided the key does not already exist in the
+                                      object's annotations.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels is a map of string keys and
+                                      values that may match replicaset and service
+                                      selectors. Each of these key/value pairs are
+                                      added to the object's labels provided the key
+                                      does not already exist in the object's labels.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Spec is the csi-node-driver DaemonSet's
+                                  PodSpec.
+                                properties:
+                                  affinity:
+                                    description: 'Affinity is a group of affinity
+                                      scheduling rules for the csi-node-driver pods.
+                                      If specified, this overrides any affinity that
+                                      may be set on the csi-node-driver DaemonSet.
+                                      If omitted, the csi-node-driver DaemonSet will
+                                      use its default value for affinity. WARNING:
+                                      Please note that this field will override the
+                                      default csi-node-driver DaemonSet affinity.'
+                                    properties:
+                                      nodeAffinity:
+                                        description: Describes node affinity scheduling
+                                          rules for the pod.
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node matches the corresponding
+                                              matchExpressions; the node(s) with the
+                                              highest sum are the most preferred.
+                                            items:
+                                              description: An empty preferred scheduling
+                                                term matches all objects with implicit
+                                                weight 0 (i.e. it's a no-op). A null
+                                                preferred scheduling term matches
+                                                no objects (i.e. is also a no-op).
+                                              properties:
+                                                preference:
+                                                  description: A node selector term,
+                                                    associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                weight:
+                                                  description: Weight associated with
+                                                    matching the corresponding nodeSelectorTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - preference
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to an update),
+                                              the system may or may not try to eventually
+                                              evict the pod from its node.
+                                            properties:
+                                              nodeSelectorTerms:
+                                                description: Required. A list of node
+                                                  selector terms. The terms are ORed.
+                                                items:
+                                                  description: A null or empty node
+                                                    selector term matches no objects.
+                                                    The requirements of them are ANDed.
+                                                    The TopologySelectorTerm type
+                                                    implements a subset of the NodeSelectorTerm.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                type: array
+                                            required:
+                                            - nodeSelectorTerms
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      podAffinity:
+                                        description: Describes pod affinity scheduling
+                                          rules (e.g. co-locate this pod in the same
+                                          node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace".
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                      podAntiAffinity:
+                                        description: Describes pod anti-affinity scheduling
+                                          rules (e.g. avoid putting this pod in the
+                                          same node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the anti-affinity expressions specified
+                                              by this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling anti-affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace".
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the anti-affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the anti-affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  containers:
+                                    description: Containers is a list of csi-node-driver
+                                      containers. If specified, this overrides the
+                                      specified csi-node-driver DaemonSet containers.
+                                      If omitted, the csi-node-driver DaemonSet will
+                                      use its default values for its containers.
+                                    items:
+                                      description: CSINodeDriverDaemonSetContainer
+                                        is a csi-node-driver DaemonSet container.
+                                      properties:
+                                        name:
+                                          description: Name is an enum which identifies
+                                            the csi-node-driver DaemonSet container
+                                            by name.
+                                          enum:
+                                          - csi-node-driver
+                                          type: string
+                                        resources:
+                                          description: Resources allows customization
+                                            of limits and requests for compute resources
+                                            such as cpu and memory. If specified,
+                                            this overrides the named csi-node-driver
+                                            DaemonSet container's resources. If omitted,
+                                            the csi-node-driver DaemonSet will use
+                                            its default value for this container's
+                                            resources.
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'NodeSelector is the csi-node-driver
+                                      pod''s scheduling constraints. If specified,
+                                      each of the key/value pairs are added to the
+                                      csi-node-driver DaemonSet nodeSelector provided
+                                      the key does not already exist in the object''s
+                                      nodeSelector. If omitted, the csi-node-driver
+                                      DaemonSet will use its default value for nodeSelector.
+                                      WARNING: Please note that this field will modify
+                                      the default csi-node-driver DaemonSet nodeSelector.'
+                                    type: object
+                                  tolerations:
+                                    description: 'Tolerations is the csi-node-driver
+                                      pod''s tolerations. If specified, this overrides
+                                      any tolerations that may be set on the csi-node-driver
+                                      DaemonSet. If omitted, the csi-node-driver DaemonSet
+                                      will use its default value for tolerations.
+                                      WARNING: Please note that this field will override
+                                      the default csi-node-driver DaemonSet tolerations.'
+                                    items:
+                                      description: The pod this Toleration is attached
+                                        to tolerates any taint that matches the triple
+                                        <key,value,effect> using the matching operator
+                                        <operator>.
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint
+                                            effect to match. Empty means match all
+                                            taint effects. When specified, allowed
+                                            values are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the
+                                            toleration applies to. Empty means match
+                                            all taint keys. If the key is empty, operator
+                                            must be Exists; this combination means
+                                            to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's
+                                            relationship to the value. Valid operators
+                                            are Exists and Equal. Defaults to Equal.
+                                            Exists is equivalent to wildcard for value,
+                                            so that a pod can tolerate all taints
+                                            of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents
+                                            the period of time the toleration (which
+                                            must be of effect NoExecute, otherwise
+                                            this field is ignored) tolerates the taint.
+                                            By default, it is not set, which means
+                                            tolerate the taint forever (do not evict).
+                                            Zero and negative values will be treated
+                                            as 0 (evict immediately) by the system.
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          description: Value is the taint value the
+                                            toleration matches to. If the operator
+                                            is Exists, the value should be empty,
+                                            otherwise just a regular string.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                    type: object
                   fipsMode:
                     description: 'FIPSMode uses images and features only that are
                       using FIPS 140-2 validated cryptographic modules and standards.
@@ -15831,7 +18892,7 @@ spec:
                       used as the image path for each image. If not specified or empty,
                       the default for each image will be used. A special case value,
                       UseDefault, is supported to explicitly specify the default image
-                      path will be used for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      path will be used for each image. \n Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                       \n This option allows configuring the `<imagePath>` portion
                       of the above format."
                     type: string
@@ -15841,7 +18902,7 @@ spec:
                       as a prefix on each image. If not specified or empty, no prefix
                       will be used. A special case value, UseDefault, is supported
                       to explicitly specify the default image prefix will be used
-                      for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      for each image. \n Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                       \n This option allows configuring the `<imagePrefix>` portion
                       of the above format."
                     type: string
@@ -15858,6 +18919,7 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
+                      x-kubernetes-map-type: atomic
                     type: array
                   kubeletVolumePluginPath:
                     description: 'KubeletVolumePluginPath optionally specifies enablement
@@ -15882,6 +18944,38 @@ spec:
                     - DockerEnterprise
                     - RKE2
                     type: string
+                  logging:
+                    description: Logging Configuration for Components
+                    properties:
+                      cni:
+                        description: Customized logging specification for calico-cni
+                          plugin
+                        properties:
+                          logFileMaxAgeDays:
+                            description: 'Default: 30 (days)'
+                            format: int32
+                            type: integer
+                          logFileMaxCount:
+                            description: 'Default: 10'
+                            format: int32
+                            type: integer
+                          logFileMaxSize:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'Default: 100Mi'
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          logSeverity:
+                            description: 'Default: Info'
+                            enum:
+                            - Error
+                            - Warning
+                            - Debug
+                            - Info
+                            type: string
+                        type: object
+                    type: object
                   nodeMetricsPort:
                     description: NodeMetricsPort specifies which port calico/node
                       serves prometheus metrics on. By default, metrics are not enabled.
@@ -15926,8 +19020,7 @@ spec:
                               by the daemonset on any given node can double if the
                               readiness check fails, and so resource intensive daemonsets
                               should take into account that they may cause evictions
-                              during disruption. This is an alpha field and requires
-                              enabling DaemonSetUpdateSurge feature gate.'
+                              during disruption.'
                             x-kubernetes-int-or-string: true
                           maxUnavailable:
                             anyOf:
@@ -15938,10 +19031,10 @@ spec:
                               absolute number (ex: 5) or a percentage of total number
                               of DaemonSet pods at the start of the update (ex: 10%).
                               Absolute number is calculated from percentage by rounding
-                              down to a minimum of one. This cannot be 0 if MaxSurge
-                              is 0 Default value is 1. Example: when this is set to
-                              30%, at most 30% of the total number of nodes that should
-                              be running the daemon pod (i.e. status.desiredNumberScheduled)
+                              up. This cannot be 0 if MaxSurge is 0 Default value
+                              is 1. Example: when this is set to 30%, at most 30%
+                              of the total number of nodes that should be running
+                              the daemon pod (i.e. status.desiredNumberScheduled)
                               can have their pods stopped for an update at any given
                               time. The update starts by stopping at most 30% of those
                               DaemonSet pods and then brings up new DaemonSet pods
@@ -15967,7 +19060,7 @@ spec:
                       from this registry. If not specified then the default registries
                       will be used. A special case value, UseDefault, is supported
                       to explicitly specify the default registries will be used. \n
-                      Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                       \n This option allows configuring the `<registry>` portion of
                       the above format."
                     type: string
@@ -16072,6 +19165,7 @@ spec:
                                         type: object
                                       type: array
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 weight:
                                   description: Weight associated with matching the
                                     corresponding nodeSelectorTerm, in the range 1-100.
@@ -16187,10 +19281,12 @@ spec:
                                         type: object
                                       type: array
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 type: array
                             required:
                             - nodeSelectorTerms
                             type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                     type: object
                   typhaDeployment:
@@ -16235,6 +19331,56 @@ spec:
                             maximum: 2147483647
                             minimum: 0
                             type: integer
+                          strategy:
+                            description: The deployment strategy to use to replace
+                              existing pods with new ones.
+                            properties:
+                              rollingUpdate:
+                                description: Rolling update config params. Present
+                                  only if DeploymentStrategyType = RollingUpdate.
+                                  to be.
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'The maximum number of pods that
+                                      can be scheduled above the desired number of
+                                      pods. Value can be an absolute number (ex: 5)
+                                      or a percentage of desired pods (ex: 10%). This
+                                      can not be 0 if MaxUnavailable is 0. Absolute
+                                      number is calculated from percentage by rounding
+                                      up. Defaults to 25%. Example: when this is set
+                                      to 30%, the new ReplicaSet can be scaled up
+                                      immediately when the rolling update starts,
+                                      such that the total number of old and new pods
+                                      do not exceed 130% of desired pods. Once old
+                                      pods have been killed, new ReplicaSet can be
+                                      scaled up further, ensuring that total number
+                                      of pods running at any time during the update
+                                      is at most 130% of desired pods.'
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'The maximum number of pods that
+                                      can be unavailable during the update. Value
+                                      can be an absolute number (ex: 5) or a percentage
+                                      of desired pods (ex: 10%). Absolute number is
+                                      calculated from percentage by rounding down.
+                                      This can not be 0 if MaxSurge is 0. Defaults
+                                      to 25%. Example: when this is set to 30%, the
+                                      old ReplicaSet can be scaled down to 70% of
+                                      desired pods immediately when the rolling update
+                                      starts. Once new pods are ready, old ReplicaSet
+                                      can be scaled down further, followed by scaling
+                                      up the new ReplicaSet, ensuring that the total
+                                      number of pods available at all times during
+                                      the update is at least 70% of desired pods.'
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
                           template:
                             description: Template describes the typha Deployment pod
                               that will be created.
@@ -16408,6 +19554,7 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 weight:
                                                   description: Weight associated with
                                                     matching the corresponding nodeSelectorTerm,
@@ -16539,10 +19686,12 @@ spec:
                                                         type: object
                                                       type: array
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 type: array
                                             required:
                                             - nodeSelectorTerms
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         type: object
                                       podAffinity:
                                         description: Describes pod affinity scheduling
@@ -16648,6 +19797,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -16660,10 +19810,7 @@ spec:
                                                         namespaces list means "this
                                                         pod's namespace". An empty
                                                         selector ({}) matches all
-                                                        namespaces. This field is
-                                                        alpha-level and is only honored
-                                                        when PodAffinityNamespaceSelector
-                                                        feature is enabled.
+                                                        namespaces.
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
@@ -16731,6 +19878,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -16741,7 +19889,7 @@ spec:
                                                         ones selected by namespaceSelector.
                                                         null or empty namespaces list
                                                         and null namespaceSelector
-                                                        means "this pod's namespace"
+                                                        means "this pod's namespace".
                                                       items:
                                                         type: string
                                                       type: array
@@ -16865,6 +20013,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -16876,9 +20025,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -16940,6 +20086,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -16949,7 +20096,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -17075,6 +20222,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaceSelector:
                                                       description: A label query over
                                                         the set of namespaces that
@@ -17087,10 +20235,7 @@ spec:
                                                         namespaces list means "this
                                                         pod's namespace". An empty
                                                         selector ({}) matches all
-                                                        namespaces. This field is
-                                                        alpha-level and is only honored
-                                                        when PodAffinityNamespaceSelector
-                                                        feature is enabled.
+                                                        namespaces.
                                                       properties:
                                                         matchExpressions:
                                                           description: matchExpressions
@@ -17158,6 +20303,7 @@ spec:
                                                             are ANDed.
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-map-type: atomic
                                                     namespaces:
                                                       description: namespaces specifies
                                                         a static list of namespace
@@ -17168,7 +20314,7 @@ spec:
                                                         ones selected by namespaceSelector.
                                                         null or empty namespaces list
                                                         and null namespaceSelector
-                                                        means "this pod's namespace"
+                                                        means "this pod's namespace".
                                                       items:
                                                         type: string
                                                       type: array
@@ -17292,6 +20438,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaceSelector:
                                                   description: A label query over
                                                     the set of namespaces that the
@@ -17303,9 +20450,6 @@ spec:
                                                     or empty namespaces list means
                                                     "this pod's namespace". An empty
                                                     selector ({}) matches all namespaces.
-                                                    This field is alpha-level and
-                                                    is only honored when PodAffinityNamespaceSelector
-                                                    feature is enabled.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -17367,6 +20511,7 @@ spec:
                                                         are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 namespaces:
                                                   description: namespaces specifies
                                                     a static list of namespace names
@@ -17376,7 +20521,7 @@ spec:
                                                     field and the ones selected by
                                                     namespaceSelector. null or empty
                                                     namespaces list and null namespaceSelector
-                                                    means "this pod's namespace"
+                                                    means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
@@ -17531,6 +20676,22 @@ spec:
                                       WARNING: Please note that this field will modify
                                       the default calico-typha Deployment nodeSelector.'
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    description: Optional duration in seconds the
+                                      pod needs to terminate gracefully. May be decreased
+                                      in delete request. Value must be non-negative
+                                      integer. The value zero indicates stop immediately
+                                      via the kill signal (no opportunity to shut
+                                      down). If this value is nil, the default grace
+                                      period will be used instead. The grace period
+                                      is the duration in seconds after the processes
+                                      running in the pod are sent a termination signal
+                                      and the time when the processes are forcibly
+                                      halted with a kill signal. Set this value longer
+                                      than the expected cleanup time for your process.
+                                      Defaults to 30 seconds.
+                                    format: int64
+                                    type: integer
                                   tolerations:
                                     description: 'Tolerations is the typha pod''s
                                       tolerations. If specified, this overrides any
@@ -17586,6 +20747,233 @@ spec:
                                           type: string
                                       type: object
                                     type: array
+                                  topologySpreadConstraints:
+                                    description: TopologySpreadConstraints describes
+                                      how a group of pods ought to spread across topology
+                                      domains. Scheduler will schedule pods in a way
+                                      which abides by the constraints. All topologySpreadConstraints
+                                      are ANDed.
+                                    items:
+                                      description: TopologySpreadConstraint specifies
+                                        how to spread matching pods among the given
+                                        topology.
+                                      properties:
+                                        labelSelector:
+                                          description: LabelSelector is used to find
+                                            matching pods. Pods that match this label
+                                            selector are counted to determine the
+                                            number of pods in their corresponding
+                                            topology domain.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: MatchLabelKeys is a set of
+                                            pod label keys to select the pods over
+                                            which spreading will be calculated. The
+                                            keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels
+                                            are ANDed with labelSelector to select
+                                            the group of existing pods over which
+                                            spreading will be calculated for the incoming
+                                            pod. Keys that don't exist in the incoming
+                                            pod labels will be ignored. A null or
+                                            empty list means only match against labelSelector.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        maxSkew:
+                                          description: 'MaxSkew describes the degree
+                                            to which pods may be unevenly distributed.
+                                            When `whenUnsatisfiable=DoNotSchedule`,
+                                            it is the maximum permitted difference
+                                            between the number of matching pods in
+                                            the target topology and the global minimum.
+                                            The global minimum is the minimum number
+                                            of matching pods in an eligible domain
+                                            or zero if the number of eligible domains
+                                            is less than MinDomains. For example,
+                                            in a 3-zone cluster, MaxSkew is set to
+                                            1, and pods with the same labelSelector
+                                            spread as 2/2/1: In this case, the global
+                                            minimum is 1. | zone1 | zone2 | zone3
+                                            | |  P P  |  P P  |   P   | - if MaxSkew
+                                            is 1, incoming pod can only be scheduled
+                                            to zone3 to become 2/2/2; scheduling it
+                                            onto zone1(zone2) would make the ActualSkew(3-1)
+                                            on zone1(zone2) violate MaxSkew(1). -
+                                            if MaxSkew is 2, incoming pod can be scheduled
+                                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                            it is used to give higher precedence to
+                                            topologies that satisfy it. It''s a required
+                                            field. Default value is 1 and 0 is not
+                                            allowed.'
+                                          format: int32
+                                          type: integer
+                                        minDomains:
+                                          description: "MinDomains indicates a minimum
+                                            number of eligible domains. When the number
+                                            of eligible domains with matching topology
+                                            keys is less than minDomains, Pod Topology
+                                            Spread treats \"global minimum\" as 0,
+                                            and then the calculation of Skew is performed.
+                                            And when the number of eligible domains
+                                            with matching topology keys equals or
+                                            greater than minDomains, this value has
+                                            no effect on scheduling. As a result,
+                                            when the number of eligible domains is
+                                            less than minDomains, scheduler won't
+                                            schedule more than maxSkew Pods to those
+                                            domains. If value is nil, the constraint
+                                            behaves as if MinDomains is equal to 1.
+                                            Valid values are integers greater than
+                                            0. When value is not nil, WhenUnsatisfiable
+                                            must be DoNotSchedule. \n For example,
+                                            in a 3-zone cluster, MaxSkew is set to
+                                            2, MinDomains is set to 5 and pods with
+                                            the same labelSelector spread as 2/2/2:
+                                            | zone1 | zone2 | zone3 | |  P P  |  P
+                                            P  |  P P  | The number of domains is
+                                            less than 5(MinDomains), so \"global minimum\"
+                                            is treated as 0. In this situation, new
+                                            pod with the same labelSelector cannot
+                                            be scheduled, because computed skew will
+                                            be 3(3 - 0) if new Pod is scheduled to
+                                            any of the three zones, it will violate
+                                            MaxSkew. \n This is a beta field and requires
+                                            the MinDomainsInPodTopologySpread feature
+                                            gate to be enabled (enabled by default)."
+                                          format: int32
+                                          type: integer
+                                        nodeAffinityPolicy:
+                                          description: "NodeAffinityPolicy indicates
+                                            how we will treat Pod's nodeAffinity/nodeSelector
+                                            when calculating pod topology spread skew.
+                                            Options are: - Honor: only nodes matching
+                                            nodeAffinity/nodeSelector are included
+                                            in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                            are ignored. All nodes are included in
+                                            the calculations. \n If this value is
+                                            nil, the behavior is equivalent to the
+                                            Honor policy. This is a alpha-level feature
+                                            enabled by the NodeInclusionPolicyInPodTopologySpread
+                                            feature flag."
+                                          type: string
+                                        nodeTaintsPolicy:
+                                          description: "NodeTaintsPolicy indicates
+                                            how we will treat node taints when calculating
+                                            pod topology spread skew. Options are:
+                                            - Honor: nodes without taints, along with
+                                            tainted nodes for which the incoming pod
+                                            has a toleration, are included. - Ignore:
+                                            node taints are ignored. All nodes are
+                                            included. \n If this value is nil, the
+                                            behavior is equivalent to the Ignore policy.
+                                            This is a alpha-level feature enabled
+                                            by the NodeInclusionPolicyInPodTopologySpread
+                                            feature flag."
+                                          type: string
+                                        topologyKey:
+                                          description: TopologyKey is the key of node
+                                            labels. Nodes that have a label with this
+                                            key and identical values are considered
+                                            to be in the same topology. We consider
+                                            each <key, value> as a "bucket", and try
+                                            to put balanced number of pods into each
+                                            bucket. We define a domain as a particular
+                                            instance of a topology. Also, we define
+                                            an eligible domain as a domain whose nodes
+                                            meet the requirements of nodeAffinityPolicy
+                                            and nodeTaintsPolicy. e.g. If TopologyKey
+                                            is "kubernetes.io/hostname", each Node
+                                            is a domain of that topology. And, if
+                                            TopologyKey is "topology.kubernetes.io/zone",
+                                            each zone is a domain of that topology.
+                                            It's a required field.
+                                          type: string
+                                        whenUnsatisfiable:
+                                          description: 'WhenUnsatisfiable indicates
+                                            how to deal with a pod if it doesn''t
+                                            satisfy the spread constraint. - DoNotSchedule
+                                            (default) tells the scheduler not to schedule
+                                            it. - ScheduleAnyway tells the scheduler
+                                            to schedule the pod in any location, but
+                                            giving higher precedence to topologies
+                                            that would help reduce the skew. A constraint
+                                            is considered "Unsatisfiable" for an incoming
+                                            pod if and only if every possible node
+                                            assignment for that pod would violate
+                                            "MaxSkew" on some topology. For example,
+                                            in a 3-zone cluster, MaxSkew is set to
+                                            1, and pods with the same labelSelector
+                                            spread as 3/1/1: | zone1 | zone2 | zone3
+                                            | | P P P |   P   |   P   | If WhenUnsatisfiable
+                                            is set to DoNotSchedule, incoming pod
+                                            can only be scheduled to zone2(zone3)
+                                            to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                            on zone2(zone3) satisfies MaxSkew(1).
+                                            In other words, the cluster can still
+                                            be imbalanced, but scheduler won''t make
+                                            it *more* imbalanced. It''s a required
+                                            field.'
+                                          type: string
+                                      required:
+                                      - maxSkew
+                                      - topologyKey
+                                      - whenUnsatisfiable
+                                      type: object
+                                    type: array
                                 type: object
                             type: object
                         type: object
@@ -17611,13 +20999,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -17699,17 +21086,9 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 
 ---
 # Source: crds/operator.tigera.io_tigerastatuses_crd.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -17830,6 +21209,8 @@ kind: ServiceAccount
 metadata:
   name: tigera-operator
   namespace: tigera-operator
+imagePullSecrets:
+  []
 ---
 # Source: tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
 # Permissions required when running the operator for a Calico cluster.
@@ -18000,7 +21381,7 @@ rules:
     verbs:
       - list
       - watch
-      - create 
+      - create
       - update
   # Needed for operator lock
   - apiGroups:
@@ -18100,7 +21481,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: tigera-operator
-          image: quay.io/tigera/operator:v1.28.5
+          image: quay.io/tigera/operator:v1.30.9
           imagePullPolicy: IfNotPresent
           command:
             - operator
@@ -18118,7 +21499,7 @@ spec:
             - name: OPERATOR_NAME
               value: "tigera-operator"
             - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
-              value: v1.28.5
+              value: v1.30.9
           envFrom:
             - configMapRef:
                 name: kubernetes-services-endpoint

--- a/ovl/k8s-cni-calico/k8s-cni-calico.sh
+++ b/ovl/k8s-cni-calico/k8s-cni-calico.sh
@@ -83,7 +83,7 @@ test_start_empty() {
 	otc 1 check_namespaces
 	if echo "$xcluster_PROXY_MODE" | grep -qi disable; then
 		kubectl create -n kube-system -f $dir/default/etc/kubernetes/calico/apiserver-configmap.yaml
-		otcw restart_kubelet
+		otcwp restart_kubelet
 	fi
 	otc 1 check_nodes
 }
@@ -100,8 +100,7 @@ test_start_vpp() {
 	#export xcluster_PROXY_MODE=disabled
 	export xcluster_CALICO_BACKEND=operator+install-vpp
 	export __mem=2G
-	export __mem1=1G
-	export __nvm=3
+	export __mem1=3G
 	test_start_empty $@
 	otcr vip_routes
 }

--- a/ovl/k8s-cni-calico/tar
+++ b/ovl/k8s-cni-calico/tar
@@ -25,16 +25,8 @@ modmaster() {
 test -n "$1" || die "No out-file"
 
 mkdir -p $tmp
-for s in $(echo "$SETUP" | tr ',' ' '); do
-	test -d $dir/$s || continue
-	cp -R $dir/$s/* $tmp
-	setup_copied=yes
-	modmaster $s
-done
-if test "$setup_copied" != "yes" && test -d $dir/default; then
-	cp -R $dir/default/* $tmp
-	modmaster default
-fi
+cp -R $dir/default/* $tmp
+modmaster default
 
 f=$GOPATH/bin/calicoctl
 mkdir -p $tmp/bin


### PR DESCRIPTION
And a major clean-up and update of the bpf and vpp backends.

A needed clean-up. Both vpp and bpf backends can be started. Bpf still has severe limitations, but vpp seem to be mostly working, except for https://github.com/projectcalico/calico/issues/8269.


