### PR TITLE
ovl/kubernetes: renew kube-proxy.config

### DIFF
--- a/ovl/kubernetes/default/etc/kubernetes/kube-proxy.config
+++ b/ovl/kubernetes/default/etc/kubernetes/kube-proxy.config
@@ -1,7 +1,8 @@
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
-bindAddress: 0.0.0.0
+#bindAddress: 0.0.0.0
 featureGates:
+bindAddressHardFail: false
 clientConnection:
   acceptContentTypes: ""
   burst: 10
@@ -13,24 +14,48 @@ configSyncPeriod: 15m0s
 conntrack:
   maxPerCore: 32768
   min: 131072
+  tcpBeLiberal: true
   tcpCloseWaitTimeout: 1h0m0s
   tcpEstablishedTimeout: 24h0m0s
+#  udpStreamTimeout: 0s
+#  udpTimeout: 0s
+#detectLocal:
+#  bridgeInterface: ""
+#  interfaceNamePrefix: ""
+#detectLocalMode: ClusterCIDR
 enableProfiling: false
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:
+  localhostNodePorts: false
   masqueradeAll: false
   masqueradeBit: 14
-  minSyncPeriod: 0s
+  minSyncPeriod: 1s
   syncPeriod: 30s
 ipvs:
   excludeCIDRs: null
   minSyncPeriod: 0s
   scheduler: ""
+  strictARP: false
   syncPeriod: 30s
+#  tcpFinTimeout: 0s
+#  tcpTimeout: 0s
+#  udpTimeout: 0s
+nftables:
+  masqueradeAll: false
+  masqueradeBit: 14
+  minSyncPeriod: 1s
+  syncPeriod: 30s
+logging:
+  flushFrequency: 5s
+  format: text
+  options:
+    json:
+      infoBufferSize: "0"
+  verbosity: 0
 metricsBindAddress: 127.0.0.1:10249
 mode: "ipvs"
 nodePortAddresses: null
 oomScoreAdj: -999
 portRange: ""
-udpIdleTimeout: 250ms
+showHiddenMetricsForVersion: ""


### PR DESCRIPTION
Needed to support the new "nftables" proxier, which is released as alpha with feature-gate NFTablesProxyMode=true in K8s v1.29.

Please see https://github.com/kubernetes/kubernetes/pull/121046 for the release note.

The `kube-proxy.config` seem to be backward compatible, at least with K8s v1.28, meaning that parsing is permissive rather than "strict", which would reject unknown yaml items.

On K8s $\ge$ v1.29, test with:
```
cdo test-template
xcluster_FEATURE_GATES=NFTablesProxyMode=true xcluster_PROXY_MODE=nftables \
./test-template.sh test --no-stop basic > $log
```
