### PR TITLE
ovl/containerd: prepare for version 2.0

### DIFF
--- a/ovl/containerd/README.md
+++ b/ovl/containerd/README.md
@@ -14,14 +14,7 @@ cdo test-template
 ./test-template.sh test basic containerd > $log
 ```
 
-`Ovl/containerd` has only been tested with "private-reg". Some images
-that are "pre-pulled" for `cri-o` must be cached;
-
-```
-for i in $(xcadmin prepulled_images); do
-  images lreg_cache $i
-done
-```
+`Ovl/containerd` has only been tested with "private-reg".
 
 
 ## Config
@@ -32,50 +25,46 @@ mkdir -p /etc/containerd
 containerd config default > /etc/containerd/config.toml
 ```
 
+Do this rather than trying to read the `containerd` documentation
+which has been outdated, incomplete and outright faulty
+([issue](https://github.com/containerd/containerd/issues/9886)).
+
 ## Private registry
 
-The start script generates a config from `/etc/spoofed-hosts`;
+The private registry is used by default. The `32cri-plugin.rc`
+generates configs. For version $lt$ 2.0 the `/etc/spoofed-hosts`
+is used. For containerd `2.0+` it's simpler:
 
 ```
-version = 2
-[plugins."io.containerd.grpc.v1.cri".registry]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-      endpoint = ["http://docker.io"]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry-1.docker.io"]
-      endpoint = ["http://registry-1.docker.io"]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
-      endpoint = ["http://k8s.gcr.io"]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
-      endpoint = ["http://gcr.io"]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.nordix.org"]
-      endpoint = ["http://registry.nordix.org"]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
-      endpoint = ["http://quay.io"]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
-      endpoint = ["http://ghcr.io"]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."projects.registry.vmware.com"]
-      endpoint = ["http://projects.registry.vmware.com"]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
-      endpoint = ["http://registry.k8s.io"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs]
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."docker.io".tls]
-      insecure_skip_verify = true
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".tls]
-      insecure_skip_verify = true
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."k8s.gcr.io".tls]
-      insecure_skip_verify = true
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."gcr.io".tls]
-      insecure_skip_verify = true
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.nordix.org".tls]
-      insecure_skip_verify = true
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."quay.io".tls]
-      insecure_skip_verify = true
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."ghcr.io".tls]
-      insecure_skip_verify = true
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."projects.registry.vmware.com".tls]
-      insecure_skip_verify = true
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.k8s.io".tls]
-      insecure_skip_verify = true
+# tree /etc/containerd
+/etc/containerd
+├── certs.d
+│   └── _default
+│       └── hosts.toml
+└── config.toml
 
+# cat /etc/containerd/config.toml
+version = 3
+[plugins.'io.containerd.cri.v1.images'.PinnedImages]
+  sandbox = "registry.k8s.io/pause:3.9"
+[plugins.'io.containerd.cri.v1.images'.registry]
+  config_path = "/etc/containerd/certs.d"
+# cat /etc/containerd/certs.d/_default/hosts.toml 
+server = "http://example.com:80"
+[host."http://example.com:80"]
+  capabilities = ["pull"]
+  skip_verify = true
 ```
+
+`example.com` is spoofed in `/etc/hosts` to the address of the private
+docker registry.
+
+
+## Pause image version
+
+The version seems hard-coded to `pause:3.8`, but it is modified in the
+`./tar` script to the same version as in `ovl/crio`. (this can
+probably be done in a less obscure way)
+
+
+

--- a/ovl/containerd/default/etc/init.d/32cri-plugin.rc
+++ b/ovl/containerd/default/etc/init.d/32cri-plugin.rc
@@ -40,11 +40,37 @@ EOF
 	done
 }
 
+# Generate a version=3 config for containerd v2.x
+config_private_reg2() {
+	local r cfgpath=/etc/containerd/certs.d
+	cat >> $cfg <<EOF
+version = 3
+[plugins.'io.containerd.cri.v1.images'.PinnedImages]
+  sandbox = "registry.k8s.io/pause:3.8"
+[plugins.'io.containerd.cri.v1.images'.registry]
+  config_path = "$cfgpath"
+EOF
+	mkdir -p $cfgpath/_default
+	cat > $cfgpath/_default/hosts.toml <<EOF
+server = "http://example.com:80"
+[host."http://example.com:80"]
+  capabilities = ["pull"]
+  skip_verify = true
+EOF
+	# Use "example.com" since it's spoofed to the docker registry address
+}
+
 crictl config --set runtime-endpoint=unix:///run/containerd/containerd.sock
 
 cfg=/etc/containerd/config.toml
 mkdir -p /etc/containerd
-test -r /etc/spoofed-hosts && config_private_reg
+if test -r /etc/spoofed-hosts; then
+	if containerd --version | grep -qF v2.; then
+		config_private_reg2
+	else
+		config_private_reg
+	fi
+fi
 
 containerd > /var/log/containerd.log 2>&1 &
 sleep 0.2


### PR DESCRIPTION
This is a major version step, and config is completely different. The version is still 1.7.11 by default, but v2.0.0-beta.2 works.

It looks like all support for 1.x versions will be dropped when 2.0 is released. This [took a while to get right](https://github.com/containerd/containerd/issues/9886).


