### PR TITLE
ovl/kubernetes: add more options to the api-server

### DIFF
--- a/ovl/kubernetes/default/etc/init.d/30kube-prep.rc
+++ b/ovl/kubernetes/default/etc/init.d/30kube-prep.rc
@@ -58,11 +58,6 @@ fi
 modprobe br-netfilter
 sysctl -w net.bridge.bridge-nf-call-iptables=1
 
-# New security updates in v1.20
-key=/srv/kubernetes/server.key
-grep -q API_FLAGS /etc/profile || \
-	echo "API_FLAGS='--service-account-signing-key-file=$key --service-account-issuer=Nemo --service-account-key-file=$key'" >> /etc/profile
-
 f=/etc/kubernetes/kube-proxy.config
 for g in $(echo $FEATURE_GATES | tr ',' ' '); do
 	g=$(echo $g | sed -e 's,=,: ,')

--- a/ovl/kubernetes/default/etc/init.d/31kube-master.rc
+++ b/ovl/kubernetes/default/etc/init.d/31kube-master.rc
@@ -43,6 +43,13 @@ apiserver() {
 		--service-account-issuer=https://kubernetes.default.svc.$DOMAIN \
 		--service-account-key-file=/srv/kubernetes/server.crt \
 		--service-account-signing-key-file=/srv/kubernetes/server.key \
+		--proxy-client-cert-file=/srv/kubernetes/server.crt \
+		--proxy-client-key-file=/srv/kubernetes/server.key \
+		--requestheader-client-ca-file=/srv/kubernetes/ca.crt \
+		--requestheader-allowed-names="" \
+		--requestheader-extra-headers-prefix=X-Remote-Extra \
+		--requestheader-group-headers=X-Remote-Group \
+		--requestheader-username-headers=X-Remote-User \
 		>> $log 2>&1
 }
 


### PR DESCRIPTION
Configure the Aggregation Layer and extension api-server. Needed to make the metrics-server work.

To test, please see https://github.com/uablrek/xcluster-ovls/tree/main/k8s-metrics-server

NOTE: The k8s-metrics-server does currently not work with k8s v1.30.0-rc.x and crio v1.28.1. Use containerd or an older K8s
