### PR TITLE
ovl/crio: upgrade to 1.29.2

### DIFF
--- a/ovl/containerd/default/etc/init.d/32cri-plugin.rc
+++ b/ovl/containerd/default/etc/init.d/32cri-plugin.rc
@@ -75,6 +75,9 @@ if test -r /etc/spoofed-hosts; then
 	fi
 fi
 
+# Containerd relies on "runc" from crio
+test -x /bin/runc || ln -s crio-runc /bin/runc
+
 containerd > /var/log/containerd.log 2>&1 &
 sleep 0.2
 

--- a/ovl/crio/README.md
+++ b/ovl/crio/README.md
@@ -16,11 +16,16 @@ Cri-o have a binary release since v1.18. It can't be downloaded with
 https://github.com/cri-o/cri-o/releases) and store it in $ARCHIVE.
 
 ```
-ver=v1.24.1
+ver=v1.29.2
 ar=cri-o.amd64.$ver.tar.gz
 mv $HOME/Downloads/$ar $ARCHIVE/$ar
 tar -C default --strip-components=1 -xf $ARCHIVE/$ar cri-o/etc/crio.conf
 ```
+
+In crio v1.29, the binaries are pre-pended with "crio-". So, "crun"
+becomes "crio-crun". To keep backward compatibility, the old names are
+still used in `crio.conf` but are corrected in the `32cri-plugin.rc` script.
+
 
 ## Test
 
@@ -64,11 +69,11 @@ make binaries
 
 ## Runtime
 
-The [runc](https://github.com/opencontainers/runc) runtime is bundled
-with the `cri-o` static release bundle.
+Both [runc](https://github.com/opencontainers/runc) and
+[crun](https://github.com/containers/crun) runtimes are included
+in the `cri-o` static release bundle. `crun` is used by default, but
+you can alter that in `crio.conf`.
 
-It is possible to replace `runc` with
-[crun](https://github.com/containers/crun)
 
 
 ## Problems

--- a/ovl/crio/default/etc/init.d/32cri-plugin.rc
+++ b/ovl/crio/default/etc/init.d/32cri-plugin.rc
@@ -12,9 +12,14 @@ hostname | grep -Eq 'vm-[0-9]+$' || die "Invalid hostname [$(hostname)]"
 i=$(hostname | cut -d- -f2 | sed -re 's,^0+,,')
 test $i -le 200 || exit 0
 
+# Crio > 1.28 uses a "crio-*" prefix for binaries
+for n in crun runc conmon; do
+	test -x /bin/crio-$n || continue
+	rm -f /bin/$n
+	sed -i -e "s,/bin/$n,/bin/crio-$n," /etc/crio/crio.conf
+done
+
 mkdir -p /var/lib/crio
-# Cri-o *requires* a default route to start(?!)
-#ip route add default via 192.168.0.250
 export CONTAINER_LOG_LEVEL
 crio > /var/log/crio.log 2>&1 &
 sleep 0.2


### PR DESCRIPTION
A _fairly_ straight-forward upgrade. The binaries are now prefixed with "crio-", e.g. "crio-crun". Please see the README.md.

