### PR TITLE
Update template ovls

### DIFF
--- a/ovl/test/README.md
+++ b/ovl/test/README.md
@@ -2,100 +2,36 @@
 
 Contains a test library and a basic test program for `xcluster` itself.
 
-The test library is written in `shell` script (not bash). There are
-some recommendations to keep tests uniform;
+The test library is written in `shell` script (not bash). And no, it
+will not use any "test framework" in the future, since those tend to
+be heavy-weight, feature bloated and go in and out of fashion quickly.
 
-#### Always have a test script in all ovl's
+There are no hard rules on howto write an ovl (except that the `tar`
+script must exist), but there are some recommendation to make life
+easier for users, and for CI:
 
-```
-ovl/ovl-name/ovl-name.sh
-ovl/ovl-name/default/bin/ovl-name_test
-```
-The `ovl-name_test` is loaded on all VMs.
-
-#### Write a summary to stderr and extensive log to stdout
-
-Normal invocation;
-```
-log=/tmp/$USER/xcluster.log
-cdo ovl-name
-./ovl-name.sh test > $log
-```
-The script shall take options "test [test-suites...]".
-
-#### The test script shall return error on failure
-
-And leave the cluster running for troubleshooting.
+* Have a script in ovl's with the same name but `.sh` extension
+* The script shall implement sub-command "test [overlays...]".
+* Write a summary to stderr and extensive log to stdout. Use the `tcase`,
+  `tlog` and `tdie` functions where appropriate
+* The script shall implement a "default" test, and invoke it if no test
+  case is specified
+* The test script shall return error on failure, and leave the cluster
+  running for troubleshooting
+* For Kubernetes tests, the script shall handle the `--cni=` option
 
 
-
-## Test program example
-
-Create an ovl called "testex" in your `$XCLUSTER_OVLPATH`. Create a
-`testex.sh` script;
-
-```sh
-#! /bin/sh
-. $($XCLUSTER ovld test)/default/usr/lib/xctest
-xcluster_start
-xcluster_stop
-```
-
-Invoke with;
-```
-log=/tmp/$USER/xcluster.log
-./testex.sh test > $log
-# To use xterm's and leave the cluster running;
-__xterm=yes __no_stop=yes ./testex.sh test > $log
-xc stop
-```
-
-This just start an `xcluster`, checks that the VMs are started, and
-stops. The options ("test ...") are ignored in this basic example
-
-Now create a `default/bin/testex_test` script;
-```sh
-#! /bin/sh
-. /etc/profile
-. /usr/lib/xctest
-tcase "Called with [$@]"
-kver=$(uname -r)
-tlog "Kernel version: $kver"
-test "$2" != "FAIL" || tdie "FAILED [$@]"
-```
-
-And alter the `testex.sh` script;
-```sh
-#! /bin/sh
-. $($XCLUSTER ovld test)/default/usr/lib/xctest
-xcluster_start
-otc 1 "my_test_test_case PASS"
-xcluster_stop
-```
-
-`otc 1 ...` invokes the `testex_test` on VM 1. Check the paramaters
-and try to change "PASS" to "FAIL".
+Normally ovls are created with `xcadmin mkovl`, which setup a test
+script.
 
 ```
-# ./testex.sh test > $log
-  09:42:05 (uablrek-XPS-13-9370): TEST CASE: Build cluster [env  testex private-reg test]
-  09:42:05 (uablrek-XPS-13-9370): TEST CASE: Cluster start (hd-k8s.img)
-  09:42:07 (uablrek-XPS-13-9370): TEST CASE: VM connectivity; 1 2 3 4 201 202 
-  09:42:07 (vm-001): TEST CASE: Called with [tcase_kernel_version PASS]
-  09:42:07 Kernel version: 5.17.8
-  09:42:08 (uablrek-XPS-13-9370): TEST CASE: Stop xcluster
-```
-
-
-## More info
-
-Please see [ovl/test-template](../test-template) for a more
-comprehensive example.
-
-
-## Xcluster self test
-
-```
-log=/tmp/$USER/xcluster.log
-./test.sh test > $log
+#xcadmin mkovl --template=template --ovldir=/tmp ovl-no-k8s
+xcadmin mkovl --ovldir=/tmp example-ovl   # (template-k8s is used by default)
+cd /tmp/example-ovl   # (cdo can't be used unless /tmp is in $XCLUSTER_OVLPATH)
+./example-ovl.sh      # Help printout
+./example-ovl.sh env  # Print influential environment variables
+export __log=/tmp/$USER/xcluster.log
+./example-ovl.sh test # Execute default tests in default environment
+# Use a different setup, and leave the cluster running
+./example-ovl.sh test --no-stop --cni=flannel default containerd
 ```


### PR DESCRIPTION
* remove the never-used `dbg()` function
* Refactor `cmd_env()`, and call it by default
* Refactor `cmd_test()`
* Add `--log=`, or `export __log=`. To use `> $log` still work, but is considered obsolete
* Work-around to allow default setting of `$__nvm` in `cmd_env()`
* Export options specified on the command line ($long_opts)
* Fix indentation
* Template for the `test_default()` function. Encouraged to simplify CI
* Handle `--cni=`. Also encouraged to simplify CI
* Special handling of `--cni=cilium`
