### PR TITLE
Enable the "command" command in busybox

### DIFF
--- a/config/busybox-1.36.1
+++ b/config/busybox-1.36.1
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.36.1
-# Fri Apr 26 08:35:30 2024
+# Mon Jun 24 21:11:22 2024
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -1150,7 +1150,7 @@ CONFIG_ASH_TEST=y
 CONFIG_ASH_SLEEP=y
 # CONFIG_ASH_HELP is not set
 CONFIG_ASH_GETOPTS=y
-# CONFIG_ASH_CMDCMD is not set
+CONFIG_ASH_CMDCMD=y
 # CONFIG_CTTYHACK is not set
 # CONFIG_HUSH is not set
 # CONFIG_SHELL_HUSH is not set


### PR DESCRIPTION
Some installers uses "command -v" to check the presence of a command

Required for [ovl/k0s](https://github.com/uablrek/xcluster-ovls/tree/main/k0s).
