### PR TITLE
Add /dev/std* links

### DIFF
--- a/image/rootfs/etc/init.d/rcS
+++ b/image/rootfs/etc/init.d/rcS
@@ -20,6 +20,13 @@ echo $TZ > /etc/TZ
 klogd -c 4
 syslogd -s 1000 -b 10
 
+# Some programs need these links
+if ! test -e /dev/stdin; then
+	ln -s /proc/self/fd/0 /dev/stdin
+	ln -s /proc/self/fd/1 /dev/stdout
+	ln -s /proc/self/fd/2 /dev/stderr
+fi
+
 # Start other services
 for n in `find /etc/init.d -name "*.rc" | sort`; do
     $n start


### PR DESCRIPTION
Some programs need these links

Notable `nftables-1.0.9` which breaks proxy-mode=nftables without `/dev/stdin`, but I assume there are others.