### PR TITLE
ovl/srv6: Refresh and use $PREFIX

### DIFF
--- a/ovl/srv6/README.md
+++ b/ovl/srv6/README.md
@@ -42,8 +42,8 @@ setup routes for them. Example from `vm-201`;
 
 ```
 # ip -6 ro
-fc00:203::/64 via 1000::1:c0a8:3cb dev eth2 metric 1024 pref medium
-fc00:204::/64 via 1000::1:c0a8:4cc dev eth3 metric 1024 pref medium
+fc00:203::/64 via $PREFIX:c0a8:3cb dev eth2 metric 1024 pref medium
+fc00:204::/64 via $PREFIX:c0a8:4cc dev eth3 metric 1024 pref medium
 ...
 ```
 
@@ -64,7 +64,7 @@ options.
 
 Start a cluster with srv6;
 ```
-./srv6.sh test start > $log
+./srv6.sh test start
 ```
 
 On the edge routers, `vm-201` and `vm-202`;
@@ -74,10 +74,10 @@ On the edge routers, `vm-201` and `vm-202`;
 
 ```
 # On vm-201;
-ip -6 route add 1000::1:192.168.2.0/120 encap seg6 mode encap segs fc00:203::6,fc00:202::6 dev eth0
+ip -6 route add $PREFIX:192.168.2.0/120 encap seg6 mode encap segs fc00:203::6,fc00:202::6 dev eth0
 ip -6 ro add fc00:201::6 encap seg6local action End.DX6 nh6 :: dev eth0 table localsid
 # On vm-202;
-ip -6 route add 1000::1:192.168.1.0/120 encap seg6 mode encap segs fc00:204::6,fc00:201::6 dev eth0
+ip -6 route add $PREFIX:192.168.1.0/120 encap seg6 mode encap segs fc00:204::6,fc00:201::6 dev eth0
 ip -6 ro add fc00:202::6 encap seg6local action End.DX6 nh6 :: dev eth0 table localsid
 ```
 
@@ -99,7 +99,7 @@ We are all set. Do some testing!
 
 ```
 # on vm-001;
-ping 1000::1:192.168.2.221
+ping $PREFIX:192.168.2.221
 # Yay!
 ```
 
@@ -109,10 +109,10 @@ You may capture traffic and inspect packets with `wireshark`;
 # On yout host;
 xc tcpdump --start 203 eth2
 # On vm-001;
-ping -c2 1000::1:192.168.2.221
+ping -c2 $PREFIX:192.168.2.221
 # On your host
-xc tcpdump --get 203 eth1
-wireshark /tmp/vm-203-eth1.pcap &
+xc tcpdump --get 203 eth2
+wireshark /tmp/vm-203-eth2.pcap &
 ```
 
 

--- a/ovl/srv6/default/bin/srv6_test
+++ b/ovl/srv6/default/bin/srv6_test
@@ -78,17 +78,17 @@ cmd_tcase_enable_srv6() {
 	# we are topology aware. IRL this would be done by a routing protocol.
 	case $(hostname) in
 		vm-201)
-			ip -6 ro add fc00:203::/64 via 1000::1:192.168.3.203
-			ip -6 ro add fc00:204::/64 via 1000::1:192.168.4.204;;
+			ip -6 ro add fc00:203::/64 via $PREFIX:192.168.3.203
+			ip -6 ro add fc00:204::/64 via $PREFIX:192.168.4.204;;
 		vm-202)
-			ip -6 ro add fc00:203::/64 via 1000::1:192.168.5.203
-			ip -6 ro add fc00:204::/64 via 1000::1:192.168.6.204;;
+			ip -6 ro add fc00:203::/64 via $PREFIX:192.168.5.203
+			ip -6 ro add fc00:204::/64 via $PREFIX:192.168.6.204;;
 		vm-203)
-			ip -6 ro add fc00:201::/64 via 1000::1:192.168.3.201
-			ip -6 ro add fc00:202::/64 via 1000::1:192.168.5.202;;
+			ip -6 ro add fc00:201::/64 via $PREFIX:192.168.3.201
+			ip -6 ro add fc00:202::/64 via $PREFIX:192.168.5.202;;
 		vm-204)
-			ip -6 ro add fc00:201::/64 via 1000::1:192.168.4.201
-			ip -6 ro add fc00:202::/64 via 1000::1:192.168.6.202;;
+			ip -6 ro add fc00:201::/64 via $PREFIX:192.168.4.201
+			ip -6 ro add fc00:202::/64 via $PREFIX:192.168.6.202;;
 		*)
 			tdie "Unknown hostname [$(hostname)]"
 	esac
@@ -123,7 +123,7 @@ cmd_tcase_sr() {
 	for s in $@; do
 		segs="$segs,fc00:$s::6"
 	done
-	ip -6 route add 1000::1:$to/120 encap seg6 mode encap \
+	ip -6 route add $PREFIX:$to/120 encap seg6 mode encap \
 		segs $segs dev eth0 || tdie
 	segs=$(echo $segs | sed -e 's,::6,::4,g')
 	ip route add $to/24 encap seg6 mode encap segs $segs dev eth0 || tdie
@@ -132,13 +132,13 @@ cmd_tcase_sr() {
 cmd_tcase_default_route() {
 	tcase "Default route; $@"
 	ip route replace default via $@ || tdie
-	ip -6 route replace default via 1000::1:$@ || tdie
+	ip -6 route replace default via $PREFIX:$@ || tdie
 }
 
 cmd_tcase_http() {
 	tcase "Test mtu by http GET $1"
 	test -n "$1" || tdie "No address"
-	local adr="[1000::1:$1]"
+	local adr="[$PREFIX:$1]"
 	curl -s http://$adr/ > /tmp/index6.html || tdie "Curl $adr"
 	diff /root/www/index.html /tmp/index6.html || tdie "Diff $adr"
 	local adr="$1"


### PR DESCRIPTION
Used hard-coded prefix "1000::1". Also some minor doc corrections, and modernize `srv6-sh`.

I used this in https://github.com/kubernetes-sigs/kube-network-policies/pull/51#issuecomment-2216969955