### PR TITLE
Multus require enable_overlapping_ranges=false

### DIFF
--- a/ovl/multus/tar
+++ b/ovl/multus/tar
@@ -55,8 +55,7 @@ if findf whereabouts-amd64; then
 	chmod a+x $f
 	v=$($f --version 2>&1 | grep whereabouts)
 	log "Including $v"
-	cp $f $tmp/opt/cni/bin/whereabouts
-	strip $tmp/opt/cni/bin/whereabouts
+	cp -L $f $tmp/opt/cni/bin/whereabouts
 fi
 
 test -n "$NODEANNOTATION_DIR" || \

--- a/ovl/multus/test/etc/kubernetes/multus/multus-crd-host-device.yaml
+++ b/ovl/multus/test/etc/kubernetes/multus/multus-crd-host-device.yaml
@@ -9,6 +9,7 @@ spec:
     "device": "eth4",
     "ipam": {
       "type": "whereabouts",
+      "enable_overlapping_ranges": false,
       "ipRanges": [
             { "range": "17.0.0.0/24" },
             { "range": "4000::17.0.0.0/120" }

--- a/ovl/multus/test/etc/kubernetes/multus/multus-crd-ipvlan.yaml
+++ b/ovl/multus/test/etc/kubernetes/multus/multus-crd-ipvlan.yaml
@@ -9,6 +9,7 @@ spec:
     "master": "eth2",
     "ipam": {
       "type": "whereabouts",
+      "enable_overlapping_ranges": false,
       "ipRanges": [
             { "range": "16.0.0.0/24" },
             { "range": "4000::16.0.0.0/120" }

--- a/ovl/multus/test/etc/kubernetes/multus/multus-crd-macvlan.yaml
+++ b/ovl/multus/test/etc/kubernetes/multus/multus-crd-macvlan.yaml
@@ -9,6 +9,7 @@ spec:
     "master": "eth3",
     "ipam": {
       "type": "whereabouts",
+      "enable_overlapping_ranges": false,
       "ipRanges": [
             { "range": "18.0.0.0/24" },
             { "range": "4000::18.0.0.0/120" }

--- a/ovl/qemu-sriov/default/etc/kubernetes/qemu-sriov/net3-nad.yaml
+++ b/ovl/qemu-sriov/default/etc/kubernetes/qemu-sriov/net3-nad.yaml
@@ -10,6 +10,7 @@ spec:
   "cniVersion": "0.4.0",
   "ipam": {
     "type": "whereabouts",
+    "enable_overlapping_ranges": false,
     "ipRanges": [{
         "range": "192.168.3.0/24",
         "exclude": ["192.168.3.0/28"]


### PR DESCRIPTION
From `v0.8.0` whereabouts fail (pods not starting) unless
```yaml
"enable_overlapping_ranges": false
```
is specified in the NADs. This is reported in https://github.com/k8snetworkplumbingwg/whereabouts/issues/507, and may be fixed, or may not. Anyway, setting this always does no harm.

The whereabouts CRDs are _not_ updated by this PR. The tests now passes with whereabouts `v1.8.0` _and_ `v.0.7.0` (v0.8.0 is backward compatible with old CRDs, at least with enable_overlapping_ranges=false), but if the CRDs are updated `v0.8.0` works but _not_ `v0.7.0` (it's not forward compatible). Eventually the CRDs should be updated.